### PR TITLE
Add tenant inventory reporting for Azure AD and Exchange

### DIFF
--- a/AzureAdDeployer.psd1
+++ b/AzureAdDeployer.psd1
@@ -124,7 +124,8 @@
                 "Microsoft.Graph.Identity.DirectoryManagement",
                 "Microsoft.Graph.DeviceManagement.Enrolment",
                 "Microsoft.Graph.Identity.SignIns",
-                "Microsoft.Graph.Devices.CorporateManagement"
+                "Microsoft.Graph.Devices.CorporateManagement",
+                "ImportExcel"
             )
 
         } # End of PSData hashtable

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Alias: `aaddepl`
 ### General
 
 - Generates a HTML report to your desktop called `Microsoft365-Report-<customer_name>-<date_time>.html`
+- Generates an Excel workbook with the same dataset for further analysis
 - Interactive console interface
 - Create Desktop icon (Windows only)
 - Automatic update check
@@ -88,6 +89,11 @@ Alias: `aaddepl`
   - BlockMsolPowerShell: show, enable
 - Device join settings: show
 - Licenses: show
+- License inventory across tenants: show
+- User inventory with licensing details: show
+- Directory role members by assignment: show
+- Devices with join type and stale status: show
+- Entra ID groups with membership metadata: show
 - Admin role assignments: show
 - User mfa status: show
 - Guest accounts: show
@@ -105,11 +111,16 @@ Alias: `aaddepl`
   - Sharing capability: show
   - Prevent external users from resharing: show
   - Default sharing link type: show
+- SharePoint and OneDrive site inventory with storage insights
 
 ### Exchange Online
 
 - Domains: show, check DKIM/DMARC/SPF
+- Domain inventory with DNS ownership insights: show
 - Mail connector: show
+- All recipients: show with metadata across detail levels
+- Group membership and configuration details
+- Public folders and permissions overview
 - User mailbox: show, set language
 - Shared mailbox: show, set language, disable login, enable copy to sent
 - Unified mailbox: show, hide from client

--- a/public/AzureActiveDirectory/Register-AADReport.ps1
+++ b/public/AzureActiveDirectory/Register-AADReport.ps1
@@ -2,6 +2,10 @@
 function Get-OrganizationReport {
     $Organization = Get-MgOrganization -Property DisplayName, Id
     $script:CustomerName = $Organization.DisplayName
+    Add-TenantReportSection -Category 'Overview' -Name 'Tenant' -Data @([pscustomobject]@{
+            DisplayName = $Organization.DisplayName
+            TenantId    = $Organization.Id
+        })
     return  "<h2>$($Organization.DisplayName) ($($Organization.Id))</h2>"
 }
 
@@ -25,14 +29,18 @@ function Get-UserSettingsReport {
     if ($EnableBlockMsolPowerShell) { Enable-BlockMsolPowerShell }
     Write-Host "Checking user settings"
     $Policy = Get-MgPolicyAuthorizationPolicy -Property BlockMsolPowerShell, DefaultUserRolePermissions
-    $Report = $Policy | Select-Object -Property @{Name = "PermissionGrantPoliciesAssigned"; Expression = { [string]$_.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned } },
+    $PolicyData = $Policy | Select-Object -Property @{Name = "PermissionGrantPoliciesAssigned"; Expression = { [string]$_.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned } },
     @{Name = "AllowedToCreateApps"; Expression = { [string]$_.DefaultUserRolePermissions.AllowedToCreateApps } },
     @{Name = "AllowedToCreateSecurityGroups"; Expression = { [string]$_.DefaultUserRolePermissions.AllowedToCreateSecurityGroups } },
     @{Name = "AllowedToCreateUnifiedGroups"; Expression = { Request-AllowedToCreateUnifiedGroups } },
     @{Name = "AllowedToCreateUnifiedGroupsGroupName"; Expression = { Request-UnifiedGroupCreationAllowedGroup } },
     @{Name = "AllowedToReadOtherUsers"; Expression = { [string]$_.DefaultUserRolePermissions.AllowedToReadOtherUsers } },
     @{Name = "AllowedToCreateTenants"; Expression = { Request-AllowedToCreateTenants } },
-    BlockMsolPowerShell | ConvertTo-Html -As List -Fragment -PreContent "<h3 id='AAD_USER_SETTINGS'>User settings</h3>" -PostContent "<p>PermissionGrantPoliciesAssigned: empty (user consent not allowed), microsoft-user-default-legacy (user consent allowed for all apps), microsoft-user-default-low (user consent allowed for low permission apps)</p><p>Unified groups = Microsoft 365 groups</p><p>AllowedToReadOtherUsers: Should only be disabled if you do not use Microsoft Planner</p><p>BlockMsolPowerShell: Should only be disabled if you do not use Azure AD Connect Sync</p>"
+    BlockMsolPowerShell
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'User settings' -Data $PolicyData
+
+    $Report = $PolicyData | ConvertTo-Html -As List -Fragment -PreContent "<h3 id='AAD_USER_SETTINGS'>User settings</h3>" -PostContent "<p>PermissionGrantPoliciesAssigned: empty (user consent not allowed), microsoft-user-default-legacy (user consent allowed for all apps), microsoft-user-default-low (user consent allowed for low permission apps)</p><p>Unified groups = Microsoft 365 groups</p><p>AllowedToReadOtherUsers: Should only be disabled if you do not use Microsoft Planner</p><p>BlockMsolPowerShell: Should only be disabled if you do not use Azure AD Connect Sync</p>"
 
     $Report = $Report -Replace "<td>PermissionGrantPoliciesAssigned:</td><td>ManagePermissionGrantsForSelf.microsoft-user-default-legacy</td>", "<td>PermissionGrantPoliciesAssigned:</td><td class='red'>microsoft-user-default-legacy</td>"
     $Report = $Report -Replace "<td>PermissionGrantPoliciesAssigned:</td><td>ManagePermissionGrantsForSelf.microsoft-user-default-low</td>", "<td>PermissionGrantPoliciesAssigned:</td><td class='orange'>microsoft-user-default-low</td>"
@@ -116,11 +124,15 @@ function Request-AllowedToCreateTenants {
 function Get-DeviceJoinSettingsReport {
     Write-Host "Checking device join settings"
     $DeviceSettings = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/policies/deviceRegistrationPolicy?$select=azureAdJoin, userDeviceQuota, multiFactorAuthConfiguration"
-    $Report = $DeviceSettings | Select-Object -Property @{Name = "Require MFA"; Expression = { if ($_.multiFactorAuthConfiguration -eq 1) { return $true } return $false } },
+    $DeviceSettingsData = $DeviceSettings | Select-Object -Property @{Name = "Require MFA"; Expression = { if ($_.multiFactorAuthConfiguration -eq 1) { return $true } return $false } },
     @{Name = "Allowed to join"; Expression = { if ($_.azureAdJoin.appliesTo -eq 1) { return "All users" } if ($_.azureAdJoin.appliesTo -eq 2) { return "Selected users" } return "No users" } },
     @{Name = "Users"; Expression = { $Users = @() ; foreach ($UserId in $_.azureAdJoin.allowedUsers) { $Users += (Get-MgUser -UserId $UserId -Property UserPrincipalName).UserPrincipalName } return $Users -join "; " } },
     @{Name = "Groups"; Expression = { $Groups = @() ; foreach ($GroupId in $_.azureAdJoin.allowedGroups) { $Groups += (Get-MgGroup -GroupId $GroupId -Property DisplayName).DisplayName } return $Groups -join "; " } },
-    userDeviceQuota | ConvertTo-Html -As List -Fragment -PreContent "<br><h3 id='AAD_DEVICE_JOIN_SETTINGS'>Device join settings</h3>"
+    userDeviceQuota
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Device join settings' -Data $DeviceSettingsData
+
+    $Report = $DeviceSettingsData | ConvertTo-Html -As List -Fragment -PreContent "<br><h3 id='AAD_DEVICE_JOIN_SETTINGS'>Device join settings</h3>"
     $Report = $Report -Replace "<td>Require MFA:</td><td>False</td>", "<td>Require MFA:</td><td class='red'>False</td>"
     $Report = $Report -Replace "<td>Allowed to join:</td><td>All users</td>", "<td>Allowed to join:</td><td class='red'>All users</td>"
     return $Report
@@ -130,7 +142,7 @@ function Get-DeviceJoinSettingsReport {
 function Get-UsedSKUReport {
     Write-Host "Checking licenses"
     $SKU = Get-MgSubscribedSku -Property SkuPartNumber, ConsumedUnits, PrepaidUnits, AppliesTo
-    return $SKU | Select-Object -Property @{Name = "Name"; Expression = { 
+    $SkuData = $SKU | Select-Object -Property @{Name = "Name"; Expression = {
             if ($_.SkuPartNumber -eq "EXCHANGESTANDARD") { return "Exchange Online (Plan 1)" }
             if ($_.SkuPartNumber -eq "EXCHANGEENTERPRISE") { return "Exchange Online (PLAN 2)" }
             if ($_.SkuPartNumber -eq "EXCHANGEARCHIVE_ADDON") { return "Exchange Online Archiving for Exchange Online" }
@@ -219,8 +231,722 @@ function Get-UsedSKUReport {
             if ($_.SkuPartNumber -eq "OFFICESUBSCRIPTION") { return "Microsoft 365 Apps for enterprise" }
             if (($_.SkuPartNumber -eq "O365_BUSINESS_ESSENTIALS") -or ($_.SkuPartNumber -eq "SMB_BUSINESS_ESSENTIALS")) { return "Microsoft 365 Business Basic" }
             else { return $_.SkuPartNumber }
-        } 
-    }, @{Name = "Total"; Expression = { $_.PrepaidUnits.Enabled } }, @{Name = "Assigned"; Expression = { $_.ConsumedUnits } } , @{Name = "Available"; Expression = { ($_.PrepaidUnits.Enabled) - ($_.ConsumedUnits) } } , AppliesTo | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_SKU'>Licenses</h3>"
+        }
+    }, @{Name = "Total"; Expression = { $_.PrepaidUnits.Enabled } }, @{Name = "Assigned"; Expression = { $_.ConsumedUnits } } , @{Name = "Available"; Expression = { ($_.PrepaidUnits.Enabled) - ($_.ConsumedUnits) } } , AppliesTo
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Licenses' -Data $SkuData
+
+    return $SkuData | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_SKU'>Licenses</h3>"
+}
+
+function Get-AllLicenseSKUs {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MSOL', 'MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    Write-Host "Gathering license inventory ($ServiceName)"
+
+    try {
+        switch ($ServiceName) {
+            'MSOL' {
+                $skus = Get-MsolAccountSku -ErrorAction Stop
+                $licenseRows = foreach ($sku in $skus) {
+                    $servicePlans = @($sku.ServiceStatus.ServicePlan)
+                    [pscustomobject]@{
+                        AccountSkuId      = $sku.AccountSkuId
+                        AccountName       = $sku.AccountName
+                        AppliesTo         = $sku.TargetClass
+                        CapabilityStatus  = $sku.CapabilityStatus
+                        SkuId             = $sku.SkuId
+                        SkuPartNumber     = $sku.SkuPartNumber
+                        PurchasedUnits    = $sku.ActiveUnits
+                        ConsumedUnits     = $sku.ConsumedUnits
+                        RemainingUnits    = $sku.ActiveUnits - $sku.ConsumedUnits
+                        ServicePlansCount = if ($servicePlans) { $servicePlans.Count } else { 0 }
+                        ServicePlans      = if ($servicePlans) { ($servicePlans.ServiceName -join ', ') } else { $null }
+                        DetailLevel       = 'combined'
+                        ServiceName       = $ServiceName
+                    }
+                }
+            }
+            'MGGraph' {
+                $skus = Get-MgSubscribedSku -ErrorAction Stop | Where-Object { $_.AppliesTo }
+                $licenseRows = foreach ($sku in $skus) {
+                    $prepaid = if ($sku.PrepaidUnits) { $sku.PrepaidUnits.Enabled } else { $null }
+                    $servicePlans = @($sku.ServicePlans)
+                    [pscustomobject]@{
+                        AccountSkuId      = $sku.AccountSkuId
+                        AccountName       = $sku.AccountName
+                        AppliesTo         = $sku.AppliesTo
+                        CapabilityStatus  = $sku.CapabilityStatus
+                        SkuId             = $sku.SkuId
+                        SkuPartNumber     = $sku.SkuPartNumber
+                        PurchasedUnits    = $prepaid
+                        ConsumedUnits     = $sku.ConsumedUnits
+                        RemainingUnits    = if ($null -ne $prepaid) { $prepaid - $sku.ConsumedUnits } else { $null }
+                        ServicePlansCount = if ($servicePlans) { $servicePlans.Count } else { 0 }
+                        ServicePlans      = if ($servicePlans) { ($servicePlans.ServicePlanName -join ', ') } else { $null }
+                        DetailLevel       = 'combined'
+                        ServiceName       = $ServiceName
+                    }
+                }
+            }
+            Default {
+                throw "Service '$ServiceName' is not supported for license inventory."
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve license inventory. $_"
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'License inventory' -Message 'Error retrieving license data'
+        return "<br><h3 id='AAD_LICENSE_INVENTORY'>License inventory</h3><p>Error retrieving license data</p>"
+    }
+
+    if (-not $licenseRows) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'License inventory'
+        return "<br><h3 id='AAD_LICENSE_INVENTORY'>License inventory</h3><p>Not found</p>"
+    }
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'License inventory' -Data $licenseRows
+
+    $tableRows = $licenseRows |
+        Select-Object SkuPartNumber, AppliesTo, PurchasedUnits, ConsumedUnits, RemainingUnits, ServicePlansCount
+
+    return $tableRows | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_LICENSE_INVENTORY'>License inventory</h3>"
+}
+
+function Get-AadUserInventoryDataset {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('MSOL', 'MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    if ($script:AadUserInventory -and
+        $script:AadUserInventoryDetailLevel -eq $DetailLevel -and
+        $script:AadUserInventoryService -eq $ServiceName) {
+        return $script:AadUserInventory
+    }
+
+    $userRows = @()
+    $basicGraph = $false
+
+    switch ($ServiceName) {
+        'MSOL' {
+            try {
+                switch ($DetailLevel) {
+                    'minimum' {
+                        $desiredProperties = @(
+                            'DisplayName', 'UserPrincipalName', 'UserType', 'LicenseAssignmentDetails', 'Licenses', 'ProxyAddresses', 'ObjectId'
+                        )
+                        $rawUsers = Get-MsolUser -All -ErrorAction Stop | Select-Object $desiredProperties
+                    }
+                    'geek' {
+                        $rawUsers = Get-MsolUser -All -ErrorAction Stop
+                    }
+                    Default {
+                        $desiredProperties = @(
+                            'DisplayName', 'UserPrincipalName', 'UserType', 'Office',
+                            'ObjectId', 'IsLicensed', 'LastDirSyncTime',
+                            'BlockCredential', 'ImmutableId', 'LicenseAssignmentDetails',
+                            'ProxyAddresses', 'SoftDeletionTimestamp', 'Title', 'UsageLocation', 'WhenCreated'
+                        )
+                        $rawUsers = Get-MsolUser -All -ErrorAction Stop | Select-Object $desiredProperties
+                    }
+                }
+            }
+            catch {
+                throw "Unable to retrieve MSOnline users. $_"
+            }
+
+            foreach ($user in $rawUsers) {
+                $proxyAddresses = @($user.ProxyAddresses) | ForEach-Object { $_ -replace '^[sS][mM][tT][pP]:' }
+                $licenseAssignments = @($user.LicenseAssignmentDetails)
+
+                $assignedLicenses = $null
+                $disabledPlans = $null
+                if ($licenseAssignments) {
+                    $assignedLicenses = $licenseAssignments.AccountSku.SkuPartNumber -join ';'
+                    $disabledPlans = $licenseAssignments.Assignments.DisabledServicePlans -join ';'
+                }
+
+                $userRows += [pscustomobject]@{
+                    DisplayName                 = $user.DisplayName
+                    UserPrincipalName           = $user.UserPrincipalName
+                    UserType                    = $user.UserType
+                    AccountEnabled              = if ($user.PSObject.Properties['BlockCredential']) { -not $user.BlockCredential } else { $null }
+                    CreatedDateTime             = $user.WhenCreated
+                    UsageLocation               = $user.UsageLocation
+                    Department                  = $user.Department
+                    JobTitle                    = $user.Title
+                    CompanyName                 = $user.CompanyName
+                    OfficeLocation              = $user.Office
+                    City                        = $user.City
+                    State                       = $user.State
+                    Country                     = $user.Country
+                    OnPremisesSyncEnabled       = $user.IsDirSynced
+                    OnPremisesLastSyncDateTime  = $user.LastDirSyncTime
+                    AssignedLicenses            = $assignedLicenses
+                    DisabledServicePlans        = $disabledPlans
+                    EnabledServicePlans         = $null
+                    LastSignInDateTime          = $null
+                    ProxyAddresses              = if ($proxyAddresses) { $proxyAddresses -join ';' } else { $null }
+                    DetailLevel                 = $DetailLevel
+                    ServiceName                 = $ServiceName
+                }
+            }
+        }
+        'MGGraph' {
+            $properties = @(
+                'Id', 'DisplayName', 'UserPrincipalName', 'UserType', 'AccountEnabled',
+                'CreatedDateTime', 'Mail', 'JobTitle', 'Department', 'CompanyName',
+                'OfficeLocation', 'City', 'State', 'Country', 'OnPremisesSyncEnabled',
+                'OnPremisesLastSyncDateTime', 'UsageLocation', 'ProxyAddresses'
+            )
+
+            try {
+                $rawUsers = Get-MgUser -All -Property $properties -ConsistencyLevel eventual -ErrorAction Stop | Where-Object { $_.Id }
+            }
+            catch {
+                if ($_.Exception.Message -like '*Neither tenant is B2C or tenant doesn''t have premium license*') {
+                    Write-Warning 'Falling back to basic Microsoft Graph user inventory.'
+                    $basicGraph = $true
+                    $rawUsers = Get-MgUser -All -ErrorAction Stop | Where-Object { $_.Id }
+                }
+                else {
+                    throw "Unable to retrieve Microsoft Graph users. $_"
+                }
+            }
+
+            foreach ($user in $rawUsers) {
+                $proxyAddresses = @($user.ProxyAddresses) | ForEach-Object { $_ -replace '^[sS][mM][tT][pP]:' }
+
+                $assignedLicenses = $null
+                $disabledPlans = $null
+                $enabledPlans = $null
+
+                if (-not $basicGraph) {
+                    try {
+                        $licenseDetails = Get-MgUserLicenseDetail -UserId $user.Id -ErrorAction Stop
+                        if ($licenseDetails) {
+                            $assignedLicenses = $licenseDetails.SkuPartNumber -join ','
+                            $disabledPlans = ($licenseDetails.ServicePlans | Where-Object ProvisioningStatus -eq 'Disabled').ServicePlanName -join ','
+                            $enabledPlans = ($licenseDetails.ServicePlans | Where-Object ProvisioningStatus -eq 'Success').ServicePlanName -join ','
+                        }
+                    }
+                    catch {
+                        Write-Verbose "Failed to retrieve license details for $($user.UserPrincipalName). $_"
+                    }
+                }
+
+                $userRows += [pscustomobject]@{
+                    DisplayName                 = $user.DisplayName
+                    UserPrincipalName           = $user.UserPrincipalName
+                    UserType                    = if ($user.UserType) { $user.UserType } elseif ($user.UserPrincipalName -like '*#EXT#*') { 'Guest' } else { 'Member' }
+                    AccountEnabled              = $user.AccountEnabled
+                    CreatedDateTime             = $user.CreatedDateTime
+                    UsageLocation               = $user.UsageLocation
+                    Department                  = $user.Department
+                    JobTitle                    = $user.JobTitle
+                    CompanyName                 = $user.CompanyName
+                    OfficeLocation              = $user.OfficeLocation
+                    City                        = $user.City
+                    State                       = $user.State
+                    Country                     = $user.Country
+                    OnPremisesSyncEnabled       = $user.OnPremisesSyncEnabled
+                    OnPremisesLastSyncDateTime  = $user.OnPremisesLastSyncDateTime
+                    AssignedLicenses            = $assignedLicenses
+                    DisabledServicePlans        = $disabledPlans
+                    EnabledServicePlans         = $enabledPlans
+                    LastSignInDateTime          = if ($user.PSObject.Properties['SignInActivity']) { $user.SignInActivity.LastSignInDateTime } else { $null }
+                    ProxyAddresses              = if ($proxyAddresses) { $proxyAddresses -join ';' } else { $null }
+                    DetailLevel                 = $DetailLevel
+                    ServiceName                 = $ServiceName
+                }
+            }
+        }
+        Default {
+            throw "Service '$ServiceName' is not supported for user inventory."
+        }
+    }
+
+    $script:AadUserInventory = $userRows
+    $script:AadUserInventoryDetailLevel = $DetailLevel
+    $script:AadUserInventoryService = $ServiceName
+    $script:AadUserInventoryMap = @{}
+    foreach ($user in $userRows) {
+        if ($user.UserPrincipalName) {
+            $script:AadUserInventoryMap[$user.UserPrincipalName.ToLower()] = $user
+        }
+    }
+
+    return $userRows
+}
+
+function Get-AllUserDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MSOL', 'MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    Write-Host "Gathering user inventory ($ServiceName, $DetailLevel detail)"
+
+    try {
+        $userRows = Get-AadUserInventoryDataset -DetailLevel $DetailLevel -ServiceName $ServiceName
+    }
+    catch {
+        Write-Warning "Unable to retrieve user inventory. $_"
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Users' -Message 'Error retrieving user data'
+        return "<br><h3 id='AAD_USERS'>Users</h3><p>Error retrieving user data</p>"
+    }
+
+    if (-not $userRows) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Users'
+        return "<br><h3 id='AAD_USERS'>Users</h3><p>Not found</p>"
+    }
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Users' -Data $userRows
+
+    switch ($DetailLevel) {
+        'minimum' {
+            $tableRows = $userRows | Select-Object DisplayName, UserPrincipalName, UserType, AccountEnabled, UsageLocation
+        }
+        Default {
+            $tableRows = $userRows | Select-Object DisplayName, UserPrincipalName, UserType, AccountEnabled, AssignedLicenses, LastSignInDateTime, OnPremisesSyncEnabled
+        }
+    }
+
+    return $tableRows | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_USERS'>Users</h3>"
+}
+
+function Get-AllOffice365Admins {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MSOL', 'MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    Write-Host "Gathering directory role members ($ServiceName)"
+
+    if ($ServiceName -eq 'MGGraph' -and -not $script:AadUserInventory) {
+        try {
+            $null = Get-AadUserInventoryDataset -DetailLevel 'combined' -ServiceName 'MGGraph'
+        }
+        catch {
+            Write-Verbose "Unable to warm user inventory cache. $_"
+        }
+    }
+
+    $assignments = $null
+
+    try {
+        switch ($ServiceName) {
+            'MSOL' {
+                $roles = Get-MsolRole -ErrorAction Stop | Select-Object Name, ObjectId
+                $assignments = New-Object System.Collections.Generic.List[object]
+                foreach ($role in $roles) {
+                    $members = Get-MsolRoleMember -RoleObjectId $role.ObjectId -ErrorAction Stop
+                    foreach ($member in $members) {
+                        $assignments.Add([pscustomobject]@{
+                                Role               = $role.Name
+                                DisplayName        = $member.DisplayName
+                                UserPrincipalName  = $member.EmailAddress
+                                ObjectType         = $member.RoleMemberType
+                                Mail               = $member.EmailAddress
+                                AccountEnabled     = $null
+                                UserType           = $null
+                                JobTitle           = $null
+                                LastSignInDateTime = $null
+                                CreatedDate        = $null
+                                GroupMailEnabled   = $null
+                                GroupMailNickname  = $null
+                                GroupType          = $null
+                            })
+                    }
+                }
+            }
+            'MGGraph' {
+                $roles = Get-MgDirectoryRole -All -ErrorAction Stop | Where-Object { $_.DisplayName }
+                $assignments = New-Object System.Collections.Generic.List[object]
+
+                foreach ($role in $roles) {
+                    $members = @()
+                    try {
+                        $members = Get-MgDirectoryRoleMember -DirectoryRoleId $role.Id -All -ErrorAction Stop
+                    }
+                    catch {
+                        Write-Verbose "Failed to retrieve members for role $($role.DisplayName). $_"
+                        continue
+                    }
+
+                    foreach ($member in $members) {
+                        $additional = $member.AdditionalProperties
+                        $odataType = if ($additional) { $additional['@odata.type'] } else { $null }
+                        if ($odataType -eq '#microsoft.graph.group') {
+                            $displayName = $additional['displayName']
+                            $mail = $additional['mail']
+                            $mailEnabled = $additional['mailEnabled']
+                            $mailNickname = $additional['mailNickname']
+                            $groupTypes = if ($additional.ContainsKey('groupTypes')) { ($additional['groupTypes'] -join ',') } else { $null }
+                            $createdDate = if ($additional.ContainsKey('createdDateTime')) { try { [datetime]$additional['createdDateTime'] } catch { $null } } else { $null }
+
+                            $assignments.Add([pscustomobject]@{
+                                    Role               = $role.DisplayName
+                                    DisplayName        = $displayName
+                                    UserPrincipalName  = $null
+                                    ObjectType         = 'Group'
+                                    Mail               = $mail
+                                    AccountEnabled     = $null
+                                    UserType           = $null
+                                    JobTitle           = $null
+                                    LastSignInDateTime = $null
+                                    CreatedDate        = $createdDate
+                                    GroupMailEnabled   = $mailEnabled
+                                    GroupMailNickname  = $mailNickname
+                                    GroupType          = $groupTypes
+                                })
+                        }
+                        else {
+                            $displayName = $additional['displayName']
+                            $upn = $additional['userPrincipalName']
+                            $mail = if ($additional.ContainsKey('mail')) { $additional['mail'] } else { $upn }
+                            $jobTitle = if ($additional.ContainsKey('jobTitle')) { $additional['jobTitle'] } else { $null }
+                            $createdDate = if ($additional.ContainsKey('createdDateTime')) { try { [datetime]$additional['createdDateTime'] } catch { $null } } else { $null }
+
+                            $userRecord = $null
+                            if ($upn -and $script:AadUserInventoryMap.ContainsKey($upn.ToLower())) {
+                                $userRecord = $script:AadUserInventoryMap[$upn.ToLower()]
+                            }
+
+                            $assignments.Add([pscustomobject]@{
+                                    Role               = $role.DisplayName
+                                    DisplayName        = $displayName
+                                    UserPrincipalName  = $upn
+                                    ObjectType         = 'User'
+                                    Mail               = $mail
+                                    AccountEnabled     = if ($userRecord) { $userRecord.AccountEnabled } elseif ($additional.ContainsKey('accountEnabled')) { $additional['accountEnabled'] } else { $null }
+                                    UserType           = if ($userRecord) { $userRecord.UserType } elseif ($additional.ContainsKey('userType')) { $additional['userType'] } else { $null }
+                                    JobTitle           = if ($userRecord) { $userRecord.JobTitle } else { $jobTitle }
+                                    LastSignInDateTime = if ($userRecord) { $userRecord.LastSignInDateTime } else { $null }
+                                    CreatedDate        = if ($userRecord) { $userRecord.CreatedDateTime } else { $createdDate }
+                                    GroupMailEnabled   = $null
+                                    GroupMailNickname  = $null
+                                    GroupType          = $null
+                                })
+                        }
+                    }
+                }
+            }
+            'Azure' {
+                throw "Service 'Azure' is not supported for directory role inventory."
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve directory role members. $_"
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Directory role members' -Message 'Error retrieving admin data'
+        return "<br><h3 id='AAD_DIRECTORY_ROLES'>Directory role members</h3><p>Error retrieving admin data</p>"
+    }
+
+    if (-not $assignments -or $assignments.Count -eq 0) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Directory role members'
+        return "<br><h3 id='AAD_DIRECTORY_ROLES'>Directory role members</h3><p>Not found</p>"
+    }
+
+    $grouped = $assignments | Group-Object DisplayName, UserPrincipalName
+
+    $finalResults = foreach ($group in $grouped) {
+        $roles = ($group.Group | Select-Object -ExpandProperty Role) -join ', '
+        $first = $group.Group | Select-Object -First 1
+        [pscustomobject]@{
+            Role               = $roles
+            RolesAssigned      = $group.Group.Count
+            DisplayName        = $first.DisplayName
+            UserPrincipalName  = $first.UserPrincipalName
+            ObjectType         = $first.ObjectType
+            Mail               = $first.Mail
+            AccountEnabled     = $first.AccountEnabled
+            UserType           = $first.UserType
+            JobTitle           = $first.JobTitle
+            LastSignInDateTime = $first.LastSignInDateTime
+            CreatedDate        = $first.CreatedDate
+            GroupMailEnabled   = $first.GroupMailEnabled
+            GroupMailNickname  = $first.GroupMailNickname
+            GroupType          = $first.GroupType
+        }
+    }
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Directory role members' -Data $finalResults
+
+    $tableRows = $finalResults | Select-Object DisplayName, UserPrincipalName, Role, RolesAssigned, ObjectType, AccountEnabled
+
+    return $tableRows | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_DIRECTORY_ROLES'>Directory role members</h3>"
+}
+
+function Get-AllDevicesReport {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    Write-Host "Gathering device inventory ($ServiceName, $DetailLevel detail)"
+
+    try {
+        switch ($ServiceName) {
+            'Azure' {
+                $devices = Get-AzureADDevice -All $true -ErrorAction Stop
+                $deviceRows = foreach ($device in $devices) {
+                    $lastLogin = $device.ApproximateLastLogonTimeStamp
+                    $lastSignIn = if ($lastLogin) { [datetime]$lastLogin } else { $null }
+                    $daysSince = if ($lastSignIn) { [math]::Floor((New-TimeSpan -Start $lastSignIn -End (Get-Date)).TotalDays) } else { $null }
+                    $staleCutoff = (Get-Date).AddMonths(-6)
+                    $deviceJoinType = switch ($device.DeviceTrustType) {
+                        'AzureAD' { 'Azure AD joined' }
+                        'WorkPlace' { 'Azure AD registered' }
+                        'ServerAd' { 'Hybrid Azure AD joined' }
+                        default { 'Unknown' }
+                    }
+                    $mdmSolution = if ($device.IsManaged) { 'Intune or SCCM' } else { 'Not managed' }
+                    $stale = if ($lastSignIn) { $lastSignIn -le $staleCutoff } else { $null }
+
+                    [pscustomobject]@{
+                        DisplayName                   = $device.DisplayName
+                        DeviceId                      = $device.DeviceId
+                        ObjectId                      = $device.ObjectId
+                        AccountEnabled                = $device.AccountEnabled
+                        OperatingSystem               = $device.DeviceOSType
+                        OperatingSystemVersion        = $device.DeviceOSVersion
+                        DeviceJoinType                = $deviceJoinType
+                        MDMSolution                   = $mdmSolution
+                        IsCompliant                   = if ($null -ne $device.IsCompliant) { $device.IsCompliant } else { 'NotApplied' }
+                        IsManaged                     = $device.IsManaged
+                        ProfileType                   = $device.ProfileType
+                        LastSignInDateTime            = $lastSignIn
+                        DaysSinceLastSignIn           = $daysSince
+                        DeviceStale                   = $stale
+                        DetailLevel                   = $DetailLevel
+                        ServiceName                   = $ServiceName
+                    }
+                }
+            }
+            'MGGraph' {
+                $devices = Get-MgDevice -All -Property Id, DisplayName, AccountEnabled, OperatingSystem, OperatingSystemVersion, ApproximateLastSignInDateTime, TrustType, IsCompliant, IsManaged, ProfileType, DeviceId -ErrorAction Stop | Where-Object { $_.Id }
+                $deviceRows = foreach ($device in $devices) {
+                    $lastSignIn = if ($device.ApproximateLastSignInDateTime) { [datetime]$device.ApproximateLastSignInDateTime } else { $null }
+                    $daysSince = if ($lastSignIn) { [math]::Floor((New-TimeSpan -Start $lastSignIn -End (Get-Date)).TotalDays) } else { $null }
+                    $staleCutoff = (Get-Date).AddMonths(-6)
+                    $deviceJoinType = switch ($device.TrustType) {
+                        'AzureAd' { 'Azure AD joined' }
+                        'ServerAd' { 'Hybrid Azure AD joined' }
+                        'Workplace' { 'Azure AD registered' }
+                        Default { 'Unknown' }
+                    }
+                    $mdmSolution = if ($device.IsManaged) { 'Intune or SCCM' } else { 'Not managed' }
+                    $stale = if ($lastSignIn) { $lastSignIn -le $staleCutoff } else { $null }
+
+                    [pscustomobject]@{
+                        DisplayName                   = $device.DisplayName
+                        DeviceId                      = $device.DeviceId
+                        ObjectId                      = $device.Id
+                        AccountEnabled                = $device.AccountEnabled
+                        OperatingSystem               = $device.OperatingSystem
+                        OperatingSystemVersion        = $device.OperatingSystemVersion
+                        DeviceJoinType                = $deviceJoinType
+                        MDMSolution                   = $mdmSolution
+                        IsCompliant                   = if ($null -ne $device.IsCompliant) { $device.IsCompliant } else { 'NotApplied' }
+                        IsManaged                     = $device.IsManaged
+                        ProfileType                   = $device.ProfileType
+                        LastSignInDateTime            = $lastSignIn
+                        DaysSinceLastSignIn           = $daysSince
+                        DeviceStale                   = $stale
+                        DetailLevel                   = $DetailLevel
+                        ServiceName                   = $ServiceName
+                    }
+                }
+            }
+            Default {
+                throw "Service '$ServiceName' is not supported for device inventory."
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve device inventory. $_"
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Devices' -Message 'Error retrieving device data'
+        return "<br><h3 id='AAD_DEVICES'>Devices</h3><p>Error retrieving device data</p>"
+    }
+
+    if (-not $deviceRows) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Devices'
+        return "<br><h3 id='AAD_DEVICES'>Devices</h3><p>Not found</p>"
+    }
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Devices' -Data $deviceRows
+
+    $tableRows = $deviceRows | Select-Object DisplayName, OperatingSystem, DeviceJoinType, DeviceStale, LastSignInDateTime
+
+    return $tableRows | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_DEVICES'>Devices</h3>"
+}
+
+function Get-EntraIDGroups {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MGGraph', 'AzureAD')]
+        [string]$ServiceName,
+
+        [Parameter(HelpMessage = 'Provide the Graph Authentication Type')]
+        [ValidateSet('SDK', 'REST')]
+        [string]$GraphAuthType = 'SDK'
+    )
+
+    Write-Host "Gathering Entra ID groups ($ServiceName, $GraphAuthType)"
+
+    if ($ServiceName -ne 'MGGraph') {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Groups' -Message "Service '$ServiceName' not supported"
+        return "<br><h3 id='AAD_GROUPS'>Groups</h3><p>Service '$ServiceName' not supported</p>"
+    }
+
+    if ($GraphAuthType -ne 'SDK') {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Groups' -Message 'Only Graph SDK is supported'
+        return "<br><h3 id='AAD_GROUPS'>Groups</h3><p>Only Microsoft Graph SDK is supported</p>"
+    }
+
+    try {
+        $groups = Get-MgGroup -All -Property Id, DisplayName, Description, GroupTypes, MailEnabled, SecurityEnabled, Mail, MembershipRule, OnPremisesSyncEnabled, OnPremisesLastSyncDateTime, CreatedDateTime, Visibility, AssignedLicenses, IsAssignableToRole -ErrorAction Stop | Where-Object { $_.Id }
+    }
+    catch {
+        Write-Warning "Unable to retrieve Entra ID groups. $_"
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Groups' -Message 'Error retrieving group data'
+        return "<br><h3 id='AAD_GROUPS'>Groups</h3><p>Error retrieving group data</p>"
+    }
+
+    if (-not $groups) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Groups'
+        return "<br><h3 id='AAD_GROUPS'>Groups</h3><p>Not found</p>"
+    }
+
+    $groupRows = foreach ($group in $groups) {
+        $membershipType = if (($group.GroupTypes -and $group.GroupTypes -contains 'DynamicMembership') -or $group.MembershipRule) { 'Dynamic' } else { 'Assigned' }
+        $groupType = if ($group.GroupTypes -and $group.GroupTypes -contains 'Unified') {
+            'Microsoft 365'
+        }
+        elseif ($group.MailEnabled -and $group.SecurityEnabled) {
+            'Mail-enabled security'
+        }
+        elseif (-not $group.MailEnabled -and $group.SecurityEnabled) {
+            'Security group'
+        }
+        elseif ($group.MailEnabled -and -not $group.SecurityEnabled) {
+            'Distribution group'
+        }
+        else {
+            'Unknown'
+        }
+
+        $memberCount = $null
+        $ownerCount = $null
+        $hasNestedMembers = $null
+
+        if ($DetailLevel -ne 'minimum') {
+            $members = @()
+            try {
+                $members = Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose "Unable to retrieve members for group $($group.DisplayName). $_"
+                $members = $null
+            }
+
+            $owners = @()
+            try {
+                $owners = Get-MgGroupOwner -GroupId $group.Id -All -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose "Unable to retrieve owners for group $($group.DisplayName). $_"
+                $owners = $null
+            }
+
+            if ($members) {
+                $memberCount = $members.Count
+                $hasNestedMembers = $false
+                foreach ($member in $members) {
+                    $memberType = $null
+                    if ($member.PSObject.Properties['AdditionalProperties']) {
+                        $memberType = $member.AdditionalProperties['@odata.type']
+                    }
+                    elseif ($member.PSObject.Properties['ODataType']) {
+                        $memberType = $member.ODataType
+                    }
+
+                    if ($memberType -eq '#microsoft.graph.group') {
+                        $hasNestedMembers = $true
+                        break
+                    }
+                }
+            }
+
+            if ($owners) {
+                $ownerCount = $owners.Count
+            }
+        }
+
+        $isManagingLicenses = if ($group.AssignedLicenses) { $group.AssignedLicenses.Count -gt 0 } else { $false }
+
+        [pscustomobject]@{
+            Id                          = $group.Id
+            DisplayName                 = $group.DisplayName
+            Description                 = $group.Description
+            GroupType                   = $groupType
+            MembershipType              = $membershipType
+            MembershipRule              = $group.MembershipRule
+            Source                      = if ($group.OnPremisesSyncEnabled) { 'On-Premises' } else { 'Cloud' }
+            Mail                        = $group.Mail
+            SecurityEnabled             = $group.SecurityEnabled
+            MailEnabled                 = $group.MailEnabled
+            IsAssignableToRole          = $group.IsAssignableToRole
+            IsManagingLicenses          = $isManagingLicenses
+            OnPremisesSyncEnabled       = $group.OnPremisesSyncEnabled
+            OnPremisesLastSyncDateTime  = $group.OnPremisesLastSyncDateTime
+            CreatedDateTime             = $group.CreatedDateTime
+            MemberCount                 = $memberCount
+            OwnerCount                  = $ownerCount
+            HasNestedMembers            = $hasNestedMembers
+            Visibility                  = $group.Visibility
+            DetailLevel                 = $DetailLevel
+            ServiceName                 = $ServiceName
+        }
+    }
+
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Groups' -Data $groupRows
+
+    $tableRows = $groupRows | Select-Object DisplayName, GroupType, MembershipType, MemberCount, OwnerCount, Source
+
+    return $tableRows | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_GROUPS'>Groups</h3>"
 }
 
 <# User Account section #>
@@ -257,7 +983,9 @@ function Get-AdminRoleReport {
         }
     }
     Write-Progress -Activity "Processed count: $ProcessedCount; Currently processing: $($Assignment.PrincipalId)" -Status "Ready" -Completed
-    return $Assignments | Where-Object { -not ($null -eq $_.DisplayName) } | Sort-Object -Property UserPrincipalName | ConvertTo-Html -Property DisplayName, UserPrincipalName, RoleName -As Table -Fragment -PreContent "<br><h3 id='AAD_ADMINS'>Admin role assignments</h3>"
+    $AdminAssignments = $Assignments | Where-Object { -not ($null -eq $_.DisplayName) } | Sort-Object -Property UserPrincipalName | Select-Object DisplayName, UserPrincipalName, RoleName
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Admin role assignments' -Data $AdminAssignments
+    return $AdminAssignments | ConvertTo-Html -Property DisplayName, UserPrincipalName, RoleName -As Table -Fragment -PreContent "<br><h3 id='AAD_ADMINS'>Admin role assignments</h3>"
 }
 
 <# BreakGlass account Section #>
@@ -266,17 +994,22 @@ function Get-BreakGlassAccountReport {
         $Create
     )
     if ($BGAccount = Get-BreakGlassAccount) {
-        $Report = $BGAccount | ConvertTo-Html -Property DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn -As Table -Fragment -PreContent "<br><h3 id='AAD_BG'>BreakGlass account</h3>"
+        $BGData = $BGAccount | Select-Object DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn
+        Add-TenantReportSection -Category 'Azure AD' -Name 'BreakGlass account' -Data $BGData
+        $Report = $BGData | ConvertTo-Html -Property DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn -As Table -Fragment -PreContent "<br><h3 id='AAD_BG'>BreakGlass account</h3>"
         $Report = $Report -Replace "<td>False</td>", "<td class='red'>False</td>"
         return $Report
 
     }
     if ($create) {
         New-BreakGlassAccount
-        $Report = Get-BreakGlassAccount | ConvertTo-Html -Property DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn -As Table -Fragment -PreContent "<br><h3 id='AAD_BG'>BreakGlass account</h3>" -PostContent "<p>Check console log for credentials</p>"
+        $NewData = Get-BreakGlassAccount | Select-Object DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn
+        Add-TenantReportSection -Category 'Azure AD' -Name 'BreakGlass account' -Data $NewData
+        $Report = $NewData | ConvertTo-Html -Property DisplayName, UserPrincipalName, AccountEnabled, GlobalAdmin, LastSignIn -As Table -Fragment -PreContent "<br><h3 id='AAD_BG'>BreakGlass account</h3>" -PostContent "<p>Check console log for credentials</p>"
         $Report = $Report -Replace "<td>False</td>", "<td class='red'>False</td>"
         return $Report
     }
+    Add-TenantReportStatus -Category 'Azure AD' -Name 'BreakGlass account'
     return "<br><h3 id='AAD_BG'>BreakGlass account</h3><p>Not found</p>"
 }
 function Get-BreakGlassAccount {
@@ -443,7 +1176,9 @@ function Get-UserMfaStatusReport {
         Add-Member -InputObject $_ -NotePropertyName "AdditionalDetail" -NotePropertyValue $AdditionalDetail
     }
     Write-Progress -Activity "Processed count: $ProcessedCount; Currently processing: $($_.DisplayName)" -Status "Ready" -Completed
-    $Report = $Users | Sort-Object -Property UserPrincipalName | ConvertTo-Html -Property DisplayName, UserPrincipalName, LicenseStatus, AccountEnabled, MFAStatus, AdditionalDetail -As Table -Fragment -PreContent "<br><h3 id='AAD_MFA'>User MFA status</h3>" -PostContent "<p>Weak: PhoneAuthentication, EmailAuthentication</p><p>Strong: Fido2, PasswordlessMSAuthenticator, AuthenticatorApp, WindowsHelloForBusiness, SoftwareOath</p>"
+    $MfaData = $Users | Sort-Object -Property UserPrincipalName | Select-Object DisplayName, UserPrincipalName, LicenseStatus, AccountEnabled, MFAStatus, AdditionalDetail
+    Add-TenantReportSection -Category 'Azure AD' -Name 'User MFA status' -Data $MfaData
+    $Report = $MfaData | ConvertTo-Html -Property DisplayName, UserPrincipalName, LicenseStatus, AccountEnabled, MFAStatus, AdditionalDetail -As Table -Fragment -PreContent "<br><h3 id='AAD_MFA'>User MFA status</h3>" -PostContent "<p>Weak: PhoneAuthentication, EmailAuthentication</p><p>Strong: Fido2, PasswordlessMSAuthenticator, AuthenticatorApp, WindowsHelloForBusiness, SoftwareOath</p>"
     $Report = $Report -Replace "<td>True</td><td>Disabled</td>", "<td>True</td><td class='red'>Disabled</td>"
     $Report = $Report -Replace "<td>True</td><td>Weak</td>", "<td>True</td><td class='orange'>Weak</td>"
     return $Report
@@ -456,9 +1191,12 @@ function Get-GuestUserReport {
     $Users = Get-MgUser -All -Filter "UserType eq 'Guest'" -Property Id, DisplayName, UserPrincipalName, AccountEnabled, SignInActivity
     Select-MgProfile -Name "v1.0"
     if (-not $Users) {
+        Add-TenantReportStatus -Category 'Azure AD' -Name 'Guest accounts'
         return "<br><h3 id='AAD_GUEST'>Guest accounts</h3><p>Not found</p>"
     }
-    return $Users | Select-Object -Property DisplayName, UserPrincipalName, AccountEnabled, @{Name = "LastSignIn"; Expression = { $_.SignInActivity.LastSignInDateTime } } | Sort-Object -Property LastSignIn | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_GUEST'>Guest accounts</h3>"
+    $GuestData = $Users | Select-Object -Property DisplayName, UserPrincipalName, AccountEnabled, @{Name = "LastSignIn"; Expression = { $_.SignInActivity.LastSignInDateTime } } | Sort-Object -Property LastSignIn
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Guest accounts' -Data $GuestData
+    return $GuestData | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_GUEST'>Guest accounts</h3>"
 }
 
 <# Security defaults section #>
@@ -474,8 +1212,10 @@ function Get-SecurityDefaultsReport {
         Update-SecurityDefaults -Enable $false
     }
     if (Request-SecurityDefaults) {
+        Add-TenantReportSection -Category 'Azure AD' -Name 'Security defaults' -Data @([pscustomobject]@{ Enabled = $true })
         return "<br><h3 id='AAD_SEC_DEFAULTS'>Security defaults</h3><p>Enabled</p>"
     }
+    Add-TenantReportSection -Category 'Azure AD' -Name 'Security defaults' -Data @([pscustomobject]@{ Enabled = $false })
     return "<br><h3 id='AAD_SEC_DEFAULTS'>Security defaults</h3><p>Disabled</p>"
 }
 function Request-SecurityDefaults {
@@ -495,22 +1235,28 @@ function Update-SecurityDefaults {
 function Get-ConditionalAccessPolicyReport {
     Write-Host "Checking conditional access policies"
     if ($Policy = Get-MgIdentityConditionalAccessPolicy -Property Id, DisplayName, State) {
-        return $Policy | ConvertTo-Html -Property DisplayName, Id, State -As Table -Fragment -PreContent "<br><h3 id='AAD_CA'>Conditional access policies</h3>"
+        $PolicyData = $Policy | Select-Object DisplayName, Id, State
+        Add-TenantReportSection -Category 'Azure AD' -Name 'Conditional access policies' -Data $PolicyData
+        return $PolicyData | ConvertTo-Html -Property DisplayName, Id, State -As Table -Fragment -PreContent "<br><h3 id='AAD_CA'>Conditional access policies</h3>"
     }
+    Add-TenantReportStatus -Category 'Azure AD' -Name 'Conditional access policies'
     return "<br><h3 id='AAD_CA'>Conditional access policies</h3><p>Not found</p>"
 }
 function Get-NamedLocationReport {
     Write-Host "Checking named locations"
     if ($Locations = Get-MgIdentityConditionalAccessNamedLocation) {
-        return $Locations | Select-Object -Property DisplayName, @{Name = "Trusted"; Expression = { $_.additionalProperties["isTrusted"] } }, @{Name = "IPRange"; Expression = {
+        $LocationData = $Locations | Select-Object -Property DisplayName, @{Name = "Trusted"; Expression = { $_.additionalProperties["isTrusted"] } }, @{Name = "IPRange"; Expression = {
                 $IpRangesReport = @()
                 foreach ($IpRange in ($_.additionalProperties["ipRanges"])) {
                     $IpRangesReport += $IpRange["cidrAddress"]
                 }
                 return $IpRangesReport
             }
-        }, @{Name = "Countries"; Expression = { $_.additionalProperties["countriesAndRegions"] } } | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_CA_LOCATIONS'>Named locations</h3>"
+        }, @{Name = "Countries"; Expression = { $_.additionalProperties["countriesAndRegions"] } }
+        Add-TenantReportSection -Category 'Azure AD' -Name 'Named locations' -Data $LocationData
+        return $LocationData | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='AAD_CA_LOCATIONS'>Named locations</h3>"
     }
+    Add-TenantReportStatus -Category 'Azure AD' -Name 'Named locations'
     return "<br><h3 id='AAD_CA_LOCATIONS'>Named locations</h3><p>Not found</p>"
 }
 
@@ -518,8 +1264,11 @@ function Get-NamedLocationReport {
 function Get-AppProtectionPolicesReport {
     Write-Host "Checking app protection policies"
     if ($Polices = Get-AppProtectionPolices) {
-        return $Polices | ConvertTo-Html -As Table -Property DisplayName, IsAssigned -Fragment -PreContent "<br><h3 id='AAD_APP_POLICY'>App protection policies</h3>"
+        $PolicyData = $Polices | Select-Object DisplayName, IsAssigned
+        Add-TenantReportSection -Category 'Azure AD' -Name 'App protection policies' -Data $PolicyData
+        return $PolicyData | ConvertTo-Html -As Table -Property DisplayName, IsAssigned -Fragment -PreContent "<br><h3 id='AAD_APP_POLICY'>App protection policies</h3>"
     }
+    Add-TenantReportStatus -Category 'Azure AD' -Name 'App protection policies'
     return "<br><h3 id='AAD_APP_POLICY'>App protection policies</h3><p>Not found</p>"
 }
 function Get-AppProtectionPolices {

--- a/public/ExchangeOnline/Register-EXOReport.ps1
+++ b/public/ExchangeOnline/Register-EXOReport.ps1
@@ -1,3 +1,73 @@
+function Join-ReportValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)]
+        $Value,
+
+        [string]$Separator = ', '
+    )
+
+    begin {
+        $items = New-Object System.Collections.Generic.List[string]
+    }
+
+    process {
+        foreach ($entry in @($Value)) {
+            if ($null -eq $entry) {
+                continue
+            }
+
+            $text = $entry.ToString().Trim()
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                $null = $items.Add($text)
+            }
+        }
+    }
+
+    end {
+        if ($items.Count -eq 0) {
+            return $null
+        }
+
+        return ($items.ToArray()) -join $Separator
+    }
+}
+
+function Get-ExchangeRecipientDataset {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel
+    )
+
+    if ($script:ExchangeRecipientCache -and $script:ExchangeRecipientCacheDetailLevel -eq $DetailLevel) {
+        return $script:ExchangeRecipientCache
+    }
+
+    $filter = "RecipientTypeDetails -ne 'DiscoveryMailbox' -and RecipientTypeDetails -ne 'MailContact' -and RecipientTypeDetails -ne 'GuestMailUser' -and RecipientTypeDetails -ne 'MailUser'"
+
+    switch ($DetailLevel) {
+        'geek' {
+            $recipients = Get-EXORecipient -PropertySets All -ResultSize Unlimited -Filter $filter -ErrorAction Stop
+        }
+        default {
+            $properties = @(
+                'ExternalDirectoryObjectId', 'DisplayName', 'Identity', 'RecipientTypeDetails', 'PrimarySMTPAddress',
+                'EmailAddresses', 'HiddenFromAddressListsEnabled', 'AddressBookPolicy',
+                'ManagedBy', 'SKUAssigned', 'WhenCreated', 'WhenSoftDeleted', 'Guid',
+                'Alias', 'Notes'
+            )
+
+            $recipients = Get-EXORecipient -Properties $properties -ResultSize Unlimited -Filter $filter -ErrorAction Stop
+        }
+    }
+
+    $script:ExchangeRecipientCache = $recipients
+    $script:ExchangeRecipientCacheDetailLevel = $DetailLevel
+    return $recipients
+}
+
 <# Mail Domain section #>
 function Get-MailDomainReport {
     Write-Host "Checking domains"
@@ -12,6 +82,7 @@ function Get-MailDomainReport {
         $DomainsReport += $Domain
     }
     Write-Progress -Activity "Processed count: $ProcessedCount; Currently processing: $($Domain.Id)" -Status "Ready" -Completed
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Domains' -Data $DomainsReport
     $Report = $DomainsReport | ConvertTo-Html -As Table -Property Id, DKIM, DMARC, SPF, "DMARC record", "SPF record", "DMARC hint", "SPF hint", "Default" -Fragment -PreContent "<h3 id='EXO_DOMAIN'>Domains</h3>"
     $Report = $Report -Replace "<td>False</td><td>False</td><td>False</td>", "<td class='red'>False</td><td class='red'>False</td><td class='red'>False</td>"
     $Report = $Report -Replace "<td>False</td><td>False</td><td>True</td>", "<td class='red'>False</td><td class='red'>False</td><td>True</td>"
@@ -25,6 +96,205 @@ function Get-MailDomainReport {
     $Report = $Report -Replace "<td>Does not protect</td>", "<td class='red'>Does not protect</td>"
     $Report = $Report -Replace "<td>No qualifier found</td>", "<td class='red'>No qualifier found</td>"
     return $Report
+}
+
+function Get-AllOffice365Domains {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MSOL', 'MGGraph', 'Azure')]
+        [string]$ServiceName
+    )
+
+    Write-Host "Gathering domain inventory ($ServiceName)"
+
+    function Get-RecipientCounts {
+        param (
+            [Parameter(Mandatory)]
+            [array]$Recipients,
+
+            [Parameter(Mandatory)]
+            [string]$DomainName
+        )
+
+        $recipientsWithPrimary = ($Recipients | Where-Object { $_.PrimarySmtpAddress -like "*@${DomainName}" }).Count
+        $recipientsWithAlias = ($Recipients | Where-Object {
+                $addresses = @($_.EmailAddresses) -split ','
+                $addresses -like "*@${DomainName}"
+            }).Count
+        $recipientsAliasOnly = ($Recipients | Where-Object {
+                $addresses = @($_.EmailAddresses) -split ','
+                ($addresses -like "smtp:*@${DomainName}") -and ($_.PrimarySmtpAddress -notlike "*@${DomainName}")
+            }).Count
+
+        [pscustomobject]@{
+            PrimarySmtpCount = $recipientsWithPrimary
+            AliasOnlyCount   = $recipientsAliasOnly
+            AliasCount       = $recipientsWithAlias
+        }
+    }
+
+    function Get-DnsHostCompanyName {
+        param (
+            [Parameter(Mandatory)]
+            [array]$NsRecords
+        )
+
+        $dnsHostMapping = @{
+            'ptd.net'               = 'PenTeleData'
+            'comcast.net'           = 'Comcast'
+            'charter.com'           = 'Charter Communications'
+            'rr.com'                = 'Road Runner'
+            'verizon.net'           = 'Verizon'
+            'cox.net'               = 'Cox Communications'
+            'sbcglobal.net'         = 'AT&T'
+            'frontiernet.net'       = 'Frontier Communications'
+            'earthlink.net'         = 'EarthLink'
+            'oraclecloud.net'       = 'Oracle'
+            'microsoft.com'         = 'Microsoft'
+            'google.com'            = 'Google'
+            'worldnic.com'          = 'Network Solutions'
+            'cloudflare.com'        = 'Cloudflare'
+            'domaincontrol.com'     = 'GoDaddy'
+            'namecheaphosting.com'  = 'Namecheap'
+        }
+
+        if (-not $NsRecords) {
+            return @()
+        }
+
+        $records = if ($NsRecords -is [array]) { $NsRecords } else { @($NsRecords) }
+
+        $mainDomains = foreach ($record in $records) {
+            $parts = $record.NameHost -split '\.'
+            if ($parts.Length -ge 2) {
+                $parts[-2..-1] -join '.'
+            }
+        }
+
+        $uniqueMainDomains = $mainDomains | Where-Object { $_ } | Select-Object -Unique
+
+        foreach ($domain in $uniqueMainDomains) {
+            if ($dnsHostMapping.ContainsKey($domain)) {
+                $dnsHostMapping[$domain]
+            }
+            else {
+                $domain
+            }
+        }
+    }
+
+    try {
+        switch ($ServiceName) {
+            'MSOL' {
+                $domains = Get-MsolDomain -ErrorAction Stop
+            }
+            'MGGraph' {
+                $domains = Get-MgDomain -ErrorAction Stop | Where-Object { $_.Id }
+            }
+            'Azure' {
+                $domains = Get-AzureADDomain -ErrorAction Stop
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve domain list from $ServiceName. $_"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Domain inventory' -Message 'Error retrieving domain data'
+        return "<br><h3 id='EXO_DOMAIN_INVENTORY'>Domain inventory</h3><p>Error retrieving domain data</p>"
+    }
+
+    if (-not $domains) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Domain inventory'
+        return "<br><h3 id='EXO_DOMAIN_INVENTORY'>Domain inventory</h3><p>Not found</p>"
+    }
+
+    $acceptedDomains = $null
+    $remoteDomains = $null
+    $recipientDataset = @()
+
+    try {
+        $acceptedDomains = Get-AcceptedDomain -ErrorAction Stop
+        $remoteDomains = Get-RemoteDomain -ErrorAction Stop | Select-Object Identity, DomainName, IsInternal, TargetDeliveryDomain, AllowedOOFType, AutoReplyEnabled, AutoForwardEnabled, DeliveryReportEnabled, NDREnabled, MeetingForwardNotificationEnabled, ContentType, TNEFEnabled, TrustedMailOutboundEnabled, TrustedMailInboundEnabled
+    }
+    catch {
+        Write-Verbose "Exchange Online domain details unavailable. $_"
+    }
+
+    try {
+        $recipientDataset = Get-ExchangeRecipientDataset -DetailLevel 'combined'
+    }
+    catch {
+        Write-Verbose "Unable to load recipient dataset for domain counts. $_"
+    }
+
+    $domainRows = foreach ($domain in $domains) {
+        switch ($ServiceName) {
+            'MSOL' {
+                $domainName = $domain.Name
+                $verified = $domain.Status
+                $authType = $domain.Authentication
+                $isDefault = $domain.IsDefault
+            }
+            { $_ -in 'MGGraph', 'Azure' } {
+                $domainName = $domain.Id
+                $verified = $domain.IsVerified
+                $authType = $domain.AuthenticationType
+                $isDefault = $domain.IsDefault
+            }
+        }
+
+        $aRecords = Resolve-DnsName -Name $domainName -Server 1.1.1.1 -Type A -ErrorAction SilentlyContinue
+        $mxRecords = Resolve-DnsName -Name $domainName -Server 1.1.1.1 -Type MX -ErrorAction SilentlyContinue
+        $nsRecords = Resolve-DnsName -Name $domainName -Server 1.1.1.1 -Type NS -ErrorAction SilentlyContinue
+
+        $dnsCompanies = if ($nsRecords) { Get-DnsHostCompanyName -NsRecords $nsRecords } else { @() }
+
+        $domainType = $null
+        if ($acceptedDomains) {
+            $match = $acceptedDomains | Where-Object { $_.DomainName -eq $domainName }
+            if ($match) {
+                $domainType = $match.DomainType
+            }
+        }
+
+        $recipientCounts = if ($recipientDataset) { Get-RecipientCounts -Recipients $recipientDataset -DomainName $domainName } else { $null }
+
+        [pscustomobject]@{
+            Domain                = $domainName
+            Verified              = $verified
+            AuthenticationType    = $authType
+            DomainType            = $domainType
+            IsDefault             = $isDefault
+            DNSCompanies          = if ($dnsCompanies) { $dnsCompanies -join ',' } else { $null }
+            NSRecords             = if ($nsRecords) { ($nsRecords.NameHost -join ',') } else { $null }
+            ARecords              = if ($aRecords) { ($aRecords.IPAddress -join ',') } else { $null }
+            MXRecords             = if ($mxRecords) { ($mxRecords.NameExchange -join ',') } else { $null }
+            Office365MailExchanger = if ($mxRecords) { (($mxRecords.NameExchange | Out-String).Trim() -like '*protection.outlook.com') } else { $false }
+            PrimarySMTPRecipients = if ($recipientCounts) { $recipientCounts.PrimarySmtpCount } else { $null }
+            AliasOnlyRecipients   = if ($recipientCounts) { $recipientCounts.AliasOnlyCount } else { $null }
+            AliasedRecipients     = if ($recipientCounts) { $recipientCounts.AliasCount } else { $null }
+            ServiceName           = $ServiceName
+        }
+    }
+
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Domain inventory' -Data $domainRows
+
+    $remoteRows = @()
+    if ($remoteDomains) {
+        $remoteRows = $remoteDomains
+        Add-TenantReportSection -Category 'Exchange Online' -Name 'Remote domains' -Data $remoteRows
+    }
+
+    $domainTable = $domainRows | Select-Object Domain, Verified, AuthenticationType, DomainType, Office365MailExchanger, PrimarySMTPRecipients, AliasedRecipients
+    $domainHtml = $domainTable | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='EXO_DOMAIN_INVENTORY'>Domain inventory</h3>"
+
+    if ($remoteRows -and $remoteRows.Count -gt 0) {
+        $remoteTable = $remoteRows | Select-Object Identity, DomainName, IsInternal, TargetDeliveryDomain, AutoReplyEnabled, AutoForwardEnabled
+        $remoteHtml = $remoteTable | ConvertTo-Html -As Table -Fragment -PreContent "<br><h3 id='EXO_REMOTE_DOMAINS'>Remote domains</h3>"
+        return $domainHtml + $remoteHtml
+    }
+
+    return $domainHtml
 }
 function Get-DMARC {
     param($Domain)
@@ -113,10 +383,24 @@ function Get-SPF {
 <# Mail connector section#>
 function Get-MailConnectorReport {
     Write-Host "Checking mail connectors"
-    if (-not ($Inbound = Get-InboundConnector)) { $InboundReport = "<br><h3 id='EXO_CONNECTOR_IN'>Inbound mail connector</h3><p>Not found</p>" }
-    else { $InboundReport = $Inbound | ConvertTo-Html -As Table -Property Name, SenderDomains, SenderIPAddresses, Enabled -Fragment -PreContent "<br><h3 id='EXO_CONNECTOR_IN'>Inbound mail connector</h3>" }
-    if (-not ($Outbound = Get-OutboundConnector -IncludeTestModeConnectors:$true)) { $OutboundReport = "<br><h3 id='EXO_CONNECTOR_OUT'>Outbound mail connector</h3><p>Not found</p>" }
-    else { $OutboundReport = $Outbound | ConvertTo-Html -As Table -Property Name, RecipientDomains, SmartHosts, Enabled -Fragment -PreContent "<br><h3 id='EXO_CONNECTOR_OUT'>Outbound mail connector</h3>" }
+    if (-not ($Inbound = Get-InboundConnector)) {
+        $InboundReport = "<br><h3 id='EXO_CONNECTOR_IN'>Inbound mail connector</h3><p>Not found</p>"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Inbound mail connector'
+    }
+    else {
+        $InboundData = $Inbound | Select-Object Name, @{Name = 'SenderDomains'; Expression = { $_.SenderDomains -join '; ' } }, @{Name = 'SenderIPAddresses'; Expression = { $_.SenderIPAddresses -join '; ' } }, Enabled
+        Add-TenantReportSection -Category 'Exchange Online' -Name 'Inbound mail connector' -Data $InboundData
+        $InboundReport = $InboundData | ConvertTo-Html -As Table -Property Name, SenderDomains, SenderIPAddresses, Enabled -Fragment -PreContent "<br><h3 id='EXO_CONNECTOR_IN'>Inbound mail connector</h3>"
+    }
+    if (-not ($Outbound = Get-OutboundConnector -IncludeTestModeConnectors:$true)) {
+        $OutboundReport = "<br><h3 id='EXO_CONNECTOR_OUT'>Outbound mail connector</h3><p>Not found</p>"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Outbound mail connector'
+    }
+    else {
+        $OutboundData = $Outbound | Select-Object Name, @{Name = 'RecipientDomains'; Expression = { $_.RecipientDomains -join '; ' } }, @{Name = 'SmartHosts'; Expression = { $_.SmartHosts -join '; ' } }, Enabled
+        Add-TenantReportSection -Category 'Exchange Online' -Name 'Outbound mail connector' -Data $OutboundData
+        $OutboundReport = $OutboundData | ConvertTo-Html -As Table -Property Name, RecipientDomains, SmartHosts, Enabled -Fragment -PreContent "<br><h3 id='EXO_CONNECTOR_OUT'>Outbound mail connector</h3>"
+    }
     $Report = @()
     $Report += $InboundReport
     $Report += $OutboundReport
@@ -124,12 +408,343 @@ function Get-MailConnectorReport {
 }
 
 <# User mailbox section #>
+function Get-AllRecipientDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel
+    )
+
+    Write-Host "Checking Exchange Online recipients ($DetailLevel detail)"
+
+    try {
+        $recipients = Get-ExchangeRecipientDataset -DetailLevel $DetailLevel
+    }
+    catch {
+        Write-Warning "Unable to retrieve Exchange Online recipients. $_"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'All recipients' -Message 'Error retrieving recipients'
+        return "<br><h3 id='EXO_RECIPIENTS'>All recipients</h3><p>Error retrieving recipient data</p>"
+    }
+
+    if (-not $recipients) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'All recipients'
+        return "<br><h3 id='EXO_RECIPIENTS'>All recipients</h3><p>Not found</p>"
+    }
+
+    switch ($DetailLevel) {
+        'minimum' {
+            $reportRows = foreach ($recipient in $recipients) {
+                [pscustomobject]@{
+                    DisplayName                   = $recipient.DisplayName
+                    PrimarySmtpAddress            = $recipient.PrimarySmtpAddress
+                    RecipientTypeDetails          = $recipient.RecipientTypeDetails
+                    HiddenFromAddressListsEnabled = $recipient.HiddenFromAddressListsEnabled
+                    WhenCreated                   = $recipient.WhenCreated
+                    DetailLevel                   = $DetailLevel
+                }
+            }
+        }
+        'geek' {
+            $reportRows = foreach ($recipient in $recipients) {
+                $object = $recipient | Select-Object *
+                if ($object.PSObject.Properties['DetailLevel']) {
+                    $object.DetailLevel = $DetailLevel
+                }
+                else {
+                    $object | Add-Member -NotePropertyName 'DetailLevel' -NotePropertyValue $DetailLevel -Force
+                }
+                $object
+            }
+        }
+        Default {
+            $reportRows = foreach ($recipient in $recipients) {
+                [pscustomobject]@{
+                    DisplayName                   = $recipient.DisplayName
+                    PrimarySmtpAddress            = $recipient.PrimarySmtpAddress
+                    RecipientTypeDetails          = $recipient.RecipientTypeDetails
+                    HiddenFromAddressListsEnabled = $recipient.HiddenFromAddressListsEnabled
+                    AddressBookPolicy             = $recipient.AddressBookPolicy
+                    ManagedBy                     = Join-ReportValue -Value $recipient.ManagedBy
+                    EmailAddresses                = Join-ReportValue -Value $recipient.EmailAddresses
+                    SKUAssigned                   = Join-ReportValue -Value $recipient.SkuAssigned
+                    WhenCreated                   = $recipient.WhenCreated
+                    WhenSoftDeleted               = $recipient.WhenSoftDeleted
+                    ExternalDirectoryObjectId     = $recipient.ExternalDirectoryObjectId
+                    Guid                          = $recipient.Guid
+                    Alias                         = $recipient.Alias
+                    Notes                         = $recipient.Notes
+                    DetailLevel                   = $DetailLevel
+                }
+            }
+        }
+    }
+
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'All recipients' -Data $reportRows
+
+    $tableRows = $reportRows |
+        Select-Object DisplayName, PrimarySmtpAddress, RecipientTypeDetails, HiddenFromAddressListsEnabled, WhenCreated
+
+    return $tableRows | ConvertTo-Html -As Table -Property DisplayName, PrimarySmtpAddress, RecipientTypeDetails, HiddenFromAddressListsEnabled, WhenCreated `
+        -Fragment -PreContent "<br><h3 id='EXO_RECIPIENTS'>All recipients</h3>"
+}
+
+function Get-ExchangeGroupDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel
+    )
+
+    Write-Host "Checking Exchange Online groups ($DetailLevel detail)"
+
+    try {
+        $recipients = Get-ExchangeRecipientDataset -DetailLevel $DetailLevel
+    }
+    catch {
+        Write-Warning "Unable to retrieve Exchange Online groups. $_"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Group details' -Message 'Error retrieving group data'
+        return "<br><h3 id='EXO_GROUPS'>Group details</h3><p>Error retrieving group data</p>"
+    }
+
+    $mailGroups = $recipients | Where-Object { $_.RecipientTypeDetails -like '*group' } | Sort-Object DisplayName
+
+    if (-not $mailGroups) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Group details'
+        return "<br><h3 id='EXO_GROUPS'>Group details</h3><p>Not found</p>"
+    }
+
+    $groupRows = foreach ($group in $mailGroups) {
+        $identity = $group.Identity.ToString()
+        $groupDetails = $null
+        $groupMembers = @()
+
+        try {
+            switch ($group.RecipientTypeDetails) {
+                'DynamicDistributionGroup' {
+                    $groupDetails = Get-DynamicDistributionGroup -Identity $identity -ErrorAction Stop
+                    $groupMembers = Get-DynamicDistributionGroupMember -Identity $identity -ErrorAction SilentlyContinue -ResultSize Unlimited
+                }
+                'GroupMailbox' {
+                    $groupDetails = Get-UnifiedGroup -Identity $identity -ErrorAction Stop
+                    $groupMembers = Get-UnifiedGroupLinks -Identity $identity -LinkType Member -ErrorAction SilentlyContinue -ResultSize Unlimited
+                }
+                Default {
+                    $groupDetails = Get-DistributionGroup -Identity $identity -ErrorAction Stop
+                    $groupMembers = Get-DistributionGroupMember -Identity $identity -ErrorAction SilentlyContinue -ResultSize Unlimited
+                }
+            }
+        }
+        catch {
+            Write-Warning "Failed to gather details for group $identity. $_"
+        }
+
+        $ownerValues = @($group.ManagedBy) | Where-Object { $_ }
+        $ownersCount = if ($ownerValues) { $ownerValues.Count } else { 0 }
+        $groupOwners = if ($ownerValues) { Join-ReportValue -Value $ownerValues } else { $null }
+
+        $memberValues = foreach ($member in @($groupMembers)) {
+            if (-not $member) { continue }
+
+            if ($member.PSObject.Properties['PrimarySmtpAddress']) {
+                $member.PrimarySmtpAddress
+                continue
+            }
+
+            if ($member.PSObject.Properties['UserPrincipalName']) {
+                $member.UserPrincipalName
+                continue
+            }
+
+            if ($member.PSObject.Properties['Name']) {
+                $member.Name
+                continue
+            }
+
+            $member.ToString()
+        }
+
+        $membersCount = if ($memberValues) { $memberValues.Count } else { 0 }
+        $groupMembersList = if ($memberValues) { ($memberValues -join ', ') } else { $null }
+
+        [pscustomobject]@{
+            DisplayName                            = $group.DisplayName
+            Identity                               = $identity
+            Alias                                  = $group.Alias
+            Notes                                  = $group.Notes
+            HiddenFromAddressListsEnabled          = $group.HiddenFromAddressListsEnabled
+            PrimarySmtpAddress                     = $group.PrimarySMTPAddress
+            RecipientTypeDetails                   = $group.RecipientTypeDetails
+            EmailAddresses                         = Join-ReportValue -Value $group.EmailAddresses
+            Owners                                 = $groupOwners
+            OwnersCount                            = $ownersCount
+            Members                                = $groupMembersList
+            MembersCount                           = $membersCount
+            ResourceProvisioningOptions            = if ($groupDetails) { Join-ReportValue -Value $groupDetails.ResourceProvisioningOptions } else { $null }
+            IsMailboxConfigured                    = if ($groupDetails) { $groupDetails.IsMailboxConfigured } else { $null }
+            HiddenGroupMembershipEnabled           = if ($groupDetails) { Join-ReportValue -Value $groupDetails.HiddenGroupMembershipEnabled } else { $null }
+            ModeratedBy                            = if ($groupDetails) { Join-ReportValue -Value $groupDetails.ModeratedBy } else { $null }
+            RequireSenderAuthenticationEnabled     = if ($groupDetails) { $groupDetails.RequireSenderAuthenticationEnabled } else { $null }
+            AcceptMessagesOnlyFrom                 = if ($groupDetails) { Join-ReportValue -Value $groupDetails.AcceptMessagesOnlyFrom } else { $null }
+            AcceptMessagesOnlyFromDLMembers        = if ($groupDetails) { Join-ReportValue -Value $groupDetails.AcceptMessagesOnlyFromDLMembers } else { $null }
+            AcceptMessagesOnlyFromSendersOrMembers = if ($groupDetails) { Join-ReportValue -Value $groupDetails.AcceptMessagesOnlyFromSendersOrMembers } else { $null }
+            RejectMessagesFrom                     = if ($groupDetails) { Join-ReportValue -Value $groupDetails.RejectMessagesFrom } else { $null }
+            RejectMessagesFromDLMembers            = if ($groupDetails) { Join-ReportValue -Value $groupDetails.RejectMessagesFromDLMembers } else { $null }
+            RejectMessagesFromSendersOrMembers     = if ($groupDetails) { Join-ReportValue -Value $groupDetails.RejectMessagesFromSendersOrMembers } else { $null }
+            AccessType                             = if ($groupDetails) { $groupDetails.AccessType } else { $null }
+            AllowAddGuests                         = if ($groupDetails) { $groupDetails.AllowAddGuests } else { $null }
+            SharePointSiteUrl                      = if ($groupDetails) { $groupDetails.SharePointSiteUrl } else { $null }
+            DetailLevel                            = $DetailLevel
+        }
+    }
+
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Group details' -Data $groupRows
+
+    $tableRows = $groupRows | Select-Object DisplayName, PrimarySmtpAddress, RecipientTypeDetails, OwnersCount, MembersCount, HiddenFromAddressListsEnabled
+
+    return $tableRows | ConvertTo-Html -As Table -Property DisplayName, PrimarySmtpAddress, RecipientTypeDetails, OwnersCount, MembersCount, HiddenFromAddressListsEnabled `
+        -Fragment -PreContent "<br><h3 id='EXO_GROUPS'>Group details</h3>"
+}
+
+function Get-AllPublicFolderDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(HelpMessage = 'Specify Exchange Environment')]
+        [ValidateSet('On-Premises', 'Office365')]
+        [string]$ExchangeEnvironment = 'Office365'
+    )
+
+    Write-Host "Checking public folders ($ExchangeEnvironment, $DetailLevel detail)"
+
+    try {
+        switch ($DetailLevel) {
+            'geek' {
+                $publicFolders = Get-PublicFolder -Recurse -ResultSize Unlimited -ErrorAction Stop | Where-Object { $_.Name -ne 'IPM_SUBTREE' }
+            }
+            default {
+                $desiredProperties = @(
+                    'Identity', 'Name', 'MailEnabled',
+                    'MailRecipientGuid', 'ParentPath', 'ContentMailboxName',
+                    'EntryId', 'FolderSize', 'HasSubfolders',
+                    'FolderClass', 'FolderPath', 'ExtendedFolderFlags'
+                )
+
+                $publicFolders = Get-PublicFolder -Recurse -ResultSize Unlimited -ErrorAction Stop |
+                    Where-Object { $_.Name -ne 'IPM_SUBTREE' } |
+                    Select-Object -Property $desiredProperties
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve public folders. $_"
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Public folders' -Message 'Error retrieving public folders'
+        return "<br><h3 id='EXO_PUBLIC_FOLDERS'>Public folders</h3><p>Error retrieving public folder data</p>"
+    }
+
+    if (-not $publicFolders) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Public folders'
+        return "<br><h3 id='EXO_PUBLIC_FOLDERS'>Public folders</h3><p>Not found</p>"
+    }
+
+    $stats = @{}
+    try {
+        $statsParams = @{ ErrorAction = 'SilentlyContinue' }
+        if ($ExchangeEnvironment -eq 'On-Premises' -and (Get-Command -Name Get-PublicFolderDatabase -ErrorAction SilentlyContinue)) {
+            $database = Get-PublicFolderDatabase -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($database) {
+                $statsParams['Server'] = $database.Identity
+            }
+        }
+
+        $folderStats = $publicFolders | Get-PublicFolderStatistics @statsParams
+        foreach ($item in @($folderStats)) {
+            if ($null -ne $item.EntryId) {
+                $stats[$item.EntryId] = $item
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve public folder statistics. $_"
+    }
+
+    $permissions = @()
+    try {
+        $permissions = $publicFolders | Get-PublicFolderClientPermission -ErrorAction SilentlyContinue
+    }
+    catch {
+        Write-Warning "Unable to retrieve public folder permissions. $_"
+    }
+
+    $detailRows = foreach ($folder in $publicFolders) {
+        $stat = $stats[$folder.EntryId]
+
+        [pscustomobject]@{
+            Name                     = $folder.Name
+            FolderPath               = if ($folder.PSObject.Properties['FolderPath']) { Join-ReportValue -Value $folder.FolderPath } else { $folder.Identity }
+            MailEnabled              = $folder.MailEnabled
+            ContentMailboxName       = $folder.ContentMailboxName
+            HasSubfolders            = $folder.HasSubfolders
+            FolderClass              = $folder.FolderClass
+            FolderSize               = if ($folder.FolderSize) { $folder.FolderSize.ToString() } else { $null }
+            ItemCount                = if ($stat) { $stat.ItemCount } else { $null }
+            LastModificationTime     = if ($stat) { $stat.LastModificationTime } else { $null }
+            OwnerCount               = if ($stat) { $stat.OwnerCount } else { $null }
+            TotalAssociatedItemSize  = if ($stat) { $stat.TotalAssociatedItemSize } else { $null }
+            TotalDeletedItemSize     = if ($stat) { $stat.TotalDeletedItemSize } else { $null }
+            TotalItemSize            = if ($stat) { $stat.TotalItemSize } else { $null }
+            MailboxOwnerId           = if ($stat) { $stat.MailboxOwnerId } else { $null }
+            DetailLevel              = $DetailLevel
+        }
+    }
+
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Public folders' -Data $detailRows
+
+    $permissionRows = foreach ($permission in @($permissions)) {
+        [pscustomobject]@{
+            FolderPath          = $permission.Identity
+            FolderName          = $permission.FolderName
+            DisplayName         = $permission.User.DisplayName
+            PrimarySmtpAddress  = if ($permission.User.RecipientPrincipal) { $permission.User.RecipientPrincipal.PrimarySmtpAddress } else { $null }
+            AccessRights        = Join-ReportValue -Value $permission.AccessRights
+            DetailLevel         = $DetailLevel
+        }
+    }
+
+    if ($permissionRows) {
+        Add-TenantReportSection -Category 'Exchange Online' -Name 'Public folder permissions' -Data $permissionRows
+    }
+    else {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Public folder permissions'
+    }
+
+    $detailsHtml = $detailRows | Select-Object Name, FolderPath, MailEnabled, ItemCount, TotalItemSize |
+        ConvertTo-Html -As Table -Property Name, FolderPath, MailEnabled, ItemCount, TotalItemSize `
+            -Fragment -PreContent "<br><h3 id='EXO_PUBLIC_FOLDERS'>Public folders</h3>"
+
+    $permissionsHtml = if ($permissionRows) {
+        $permissionRows | Select-Object FolderPath, DisplayName, PrimarySmtpAddress, AccessRights |
+            ConvertTo-Html -As Table -Property FolderPath, DisplayName, PrimarySmtpAddress, AccessRights `
+                -Fragment -PreContent "<br><h3 id='EXO_PUBLIC_FOLDER_PERMISSIONS'>Public folder permissions</h3>"
+    }
+    else {
+        "<br><h3 id='EXO_PUBLIC_FOLDER_PERMISSIONS'>Public folder permissions</h3><p>Not found</p>"
+    }
+
+    return @($detailsHtml, $permissionsHtml)
+}
+
 function Get-UserMailboxReport {
     param(
         [System.Boolean]$Language
     )
     Write-Host "Checking user mailboxes"
     if ( -not ($Mailboxes = Get-EXOMailbox -RecipientTypeDetails UserMailbox -ResultSize:Unlimited -Properties DisplayName, UserPrincipalName)) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'User mailbox'
         return "<br><h3 id='EXO_USER'>User mailbox</h3><p>Not found</p>"
     }
     if ($Language) {
@@ -142,7 +757,9 @@ function Get-UserMailboxReport {
         $MailboxReport += Get-MailboxLoginAndLocation $Mailbox
     }
     Write-Progress -Activity "Processed count: $ProcessedCount; Currently processing: $($Mailbox.DisplayName)" -Status "Ready" -Completed
-    return $MailboxReport | ConvertTo-Html -As Table -Property UserPrincipalName, DisplayName, Language, TimeZone, LoginAllowed `
+    $UserMailboxData = $MailboxReport | Select-Object UserPrincipalName, DisplayName, Language, TimeZone, LoginAllowed
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'User mailbox' -Data $UserMailboxData
+    return $UserMailboxData | ConvertTo-Html -As Table -Property UserPrincipalName, DisplayName, Language, TimeZone, LoginAllowed `
         -Fragment -PreContent "<br><h3 id='EXO_USER'>User mailbox</h3>"
 }
 function Update-MailboxLang {
@@ -163,6 +780,7 @@ function Get-SharedMailboxReport {
     Write-Host "Checking shared mailboxes"
     if ( -not ($Mailboxes = Get-EXOMailbox -RecipientTypeDetails SharedMailbox -ResultSize:Unlimited -Properties DisplayName,
             UserPrincipalName, MessageCopyForSentAsEnabled, MessageCopyForSendOnBehalfEnabled)) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Shared mailbox'
         return "<br><h3 id='EXO_SHARED'>Shared mailbox</h3><p>Not found</p>"
     }
     if ($Language) { Update-MailboxLang -Mailbox $Mailboxes }
@@ -179,7 +797,10 @@ function Get-SharedMailboxReport {
         $MailboxReport += Get-MailboxLoginAndLocation $Mailbox
     }
     Write-Progress -Activity "Processed count: $ProcessedCount; Currently processing: $($Mailbox.DisplayName)" -Status "Ready" -Completed
-    $Report = $MailboxReport | ConvertTo-Html -As Table -Property UserPrincipalName, DisplayName, Language, TimeZone, MessageCopyForSentAsEnabled,
+    $SharedMailboxData = $MailboxReport | Select-Object UserPrincipalName, DisplayName, Language, TimeZone, MessageCopyForSentAsEnabled,
+    MessageCopyForSendOnBehalfEnabled, LoginAllowed
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Shared mailbox' -Data $SharedMailboxData
+    $Report = $SharedMailboxData | ConvertTo-Html -As Table -Property UserPrincipalName, DisplayName, Language, TimeZone, MessageCopyForSentAsEnabled,
     MessageCopyForSendOnBehalfEnabled, LoginAllowed -Fragment -PreContent "<br><h3 id='EXO_SHARED'>Shared mailbox</h3>"
     $Report = $Report -Replace "<td>True</td><td>True</td><td>True</td>", "<td>True</td><td>True</td><td class='red'>True</td>"
     $Report = $Report -Replace "<td>False</td><td>False</td><td>True</td>", "<td>False</td><td>False</td><td class='red'>True</td>"
@@ -212,6 +833,7 @@ function Get-UnifiedMailboxReport {
     )
     Write-Host "Checking unified mailboxes"
     if ( -not ($Mailboxes = Get-UnifiedGroup -ResultSize Unlimited)) {
+        Add-TenantReportStatus -Category 'Exchange Online' -Name 'Unified mailbox'
         return "<br><h3 id='EXO_UNIFIED'>Unified mailbox</h3><p>Not found</p>"
     }
     if ($HideFromClient) {
@@ -219,5 +841,7 @@ function Get-UnifiedMailboxReport {
         $Mailboxes | Set-UnifiedGroup -HiddenFromExchangeClientsEnabled:$true -HiddenFromAddressListsEnabled:$false
         $Mailboxes = Get-UnifiedGroup -ResultSize Unlimited 
     }
-    return $Mailboxes | Sort-Object -Property PrimarySmtpAddress | ConvertTo-Html -As Table -Property DisplayName, PrimarySmtpAddress, HiddenFromAddressListsEnabled, HiddenFromExchangeClientsEnabled -Fragment -PreContent "<br><h3 id='EXO_UNIFIED'>Unified mailbox</h3>" -PostContent "<p>Unified groups = Microsoft 365 groups</p>"
+    $UnifiedData = $Mailboxes | Sort-Object -Property PrimarySmtpAddress | Select-Object DisplayName, PrimarySmtpAddress, HiddenFromAddressListsEnabled, HiddenFromExchangeClientsEnabled
+    Add-TenantReportSection -Category 'Exchange Online' -Name 'Unified mailbox' -Data $UnifiedData
+    return $UnifiedData | ConvertTo-Html -As Table -Property DisplayName, PrimarySmtpAddress, HiddenFromAddressListsEnabled, HiddenFromExchangeClientsEnabled -Fragment -PreContent "<br><h3 id='EXO_UNIFIED'>Unified mailbox</h3>" -PostContent "<p>Unified groups = Microsoft 365 groups</p>"
 }

--- a/public/HTML/Get-TableOfContents.ps1
+++ b/public/HTML/Get-TableOfContents.ps1
@@ -5,11 +5,16 @@ function Get-AADTableOfContents {
        <li><a href="#AAD_USER_SETTINGS">User settings</a></li>
        <li><a href="#AAD_DEVICE_JOIN_SETTINGS">Device join settings</a></li>
        <li><a href="#AAD_SKU">Licenses</a></li>
-       <li><a href="#AAD_ADMINS">Admin role assignments</a></li>
-       <li><a href="#AAD_BG">BreakGlass account</a></li>
-       <li><a href="#AAD_MFA">User MFA status</a></li>
-       <li><a href="#AAD_GUEST">Guest accounts</a></li>
-       <li><a href="#AAD_SEC_DEFAULTS">Security defaults</a></li>
+        <li><a href="#AAD_LICENSE_INVENTORY">License inventory</a></li>
+        <li><a href="#AAD_USERS">Users</a></li>
+        <li><a href="#AAD_DIRECTORY_ROLES">Directory role members</a></li>
+        <li><a href="#AAD_DEVICES">Devices</a></li>
+        <li><a href="#AAD_GROUPS">Groups</a></li>
+        <li><a href="#AAD_ADMINS">Admin role assignments</a></li>
+        <li><a href="#AAD_BG">BreakGlass account</a></li>
+        <li><a href="#AAD_MFA">User MFA status</a></li>
+        <li><a href="#AAD_GUEST">Guest accounts</a></li>
+        <li><a href="#AAD_SEC_DEFAULTS">Security defaults</a></li>
        <li><a href="#AAD_CA">Conditional access policies</a></li>
        <li><a href="#AAD_CA_LOCATIONS">Named locations</a></li>
        <li><a href="#AAD_APP_POLICY">App protection policies</a></li>
@@ -21,6 +26,8 @@ function Get-SPOTableOfContents {
    <h3 class='TOC'><a href="#SPO">SharePoint Online</a></h3>
    <ul>
        <li><a href="#SPO_SETTINGS">Tenant settings</a></li>
+       <li><a href="#SPO_SITES">SharePoint sites</a></li>
+       <li><a href="#SPO_ONEDRIVE">OneDrive sites</a></li>
    </ul>
 "@
 }
@@ -29,8 +36,13 @@ function Get-EXOTableOfContents {
    <h3 class='TOC'><a href="#EXO">Exchange Online</a></h3>
    <ul>
        <li><a href="#EXO_DOMAIN">Domains</a></li>
-       <li><a href="#EXO_CONNECTOR_IN">Inbound mail connector</a></li>
-       <li><a href="#EXO_CONNECTOR_OUT">Outbound mail connector</a></li>
+        <li><a href="#EXO_DOMAIN_INVENTORY">Domain inventory</a></li>
+        <li><a href="#EXO_CONNECTOR_IN">Inbound mail connector</a></li>
+        <li><a href="#EXO_CONNECTOR_OUT">Outbound mail connector</a></li>
+        <li><a href="#EXO_RECIPIENTS">All recipients</a></li>
+        <li><a href="#EXO_GROUPS">Group details</a></li>
+        <li><a href="#EXO_PUBLIC_FOLDERS">Public folders</a></li>
+       <li><a href="#EXO_PUBLIC_FOLDER_PERMISSIONS">Public folder permissions</a></li>
        <!-- <li><a href="#EXO_USER">User mailbox</a></li> -->
        <li><a href="#EXO_SHARED">Shared mailbox</a></li>
        <li><a href="#EXO_UNIFIED">Unified mailbox</a></li>

--- a/public/Helper/Invoke-DependencyCheck.ps1
+++ b/public/Helper/Invoke-DependencyCheck.ps1
@@ -32,8 +32,11 @@ Function Get-AllModulesInstalled {
             ModuleName    = "Microsoft.Graph.Identity.SignIns"; 
             ModuleVersion = "1.28.0"; 
         }, @{
-            ModuleName    = "Microsoft.Graph.Devices.CorporateManagement"; 
-            ModuleVersion = "1.28.0"; 
+            ModuleName    = "Microsoft.Graph.Devices.CorporateManagement";
+            ModuleVersion = "1.28.0";
+        }, @{
+            ModuleName    = "ImportExcel";
+            ModuleVersion = "7.8.8";
         }
     )
 

--- a/public/Helper/Register-TenantReportContext.ps1
+++ b/public/Helper/Register-TenantReportContext.ps1
@@ -1,0 +1,219 @@
+function Initialize-TenantReportContext {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Title,
+
+        [Parameter()]
+        [string]$Version
+    )
+
+    $script:TenantReportContext = [ordered]@{
+        Title          = $Title
+        Version        = $Version
+        Generated      = Get-Date
+        Sections       = [ordered]@{}
+        WorksheetNames = @{}
+    }
+
+    $metadata = [pscustomobject]@{
+        Title    = $Title
+        Version  = $Version
+        Generated = $script:TenantReportContext.Generated
+    }
+
+    $script:TenantReportContext.Sections['Report Metadata'] = New-Object System.Collections.Generic.List[object]
+    $null = $script:TenantReportContext.Sections['Report Metadata'].Add($metadata)
+}
+
+function Reset-TenantReportContext {
+    [CmdletBinding()]
+    param()
+
+    $script:TenantReportContext = $null
+}
+
+function Add-TenantReportSection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter()]
+        [object[]]$Data,
+
+        [Parameter()]
+        [string]$Category,
+
+        [Parameter()]
+        [string]$EmptyMessage = 'No data available'
+    )
+
+    if (-not $script:TenantReportContext) {
+        Initialize-TenantReportContext -Title $script:ReportTitle -Version $script:ModuleVersion
+    }
+
+    if ([string]::IsNullOrEmpty($Name)) {
+        throw 'Section name cannot be empty.'
+    }
+
+    $sectionKey = if ([string]::IsNullOrWhiteSpace($Category)) { $Name } else { "${Category}\$Name" }
+
+    if (-not $script:TenantReportContext.Sections.Contains($sectionKey)) {
+        $script:TenantReportContext.Sections[$sectionKey] = New-Object System.Collections.Generic.List[object]
+    }
+
+    if (-not $Data -or $Data.Count -eq 0) {
+        $null = $script:TenantReportContext.Sections[$sectionKey].Add([pscustomobject]@{ Status = $EmptyMessage })
+        return
+    }
+
+    foreach ($item in $Data) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        if ($item -is [System.Collections.IDictionary]) {
+            $object = [pscustomobject]$item
+        }
+        elseif ($item -is [System.Management.Automation.PSObject]) {
+            $object = $item | Select-Object *
+        }
+        else {
+            $object = [pscustomobject]$item
+        }
+
+        $null = $script:TenantReportContext.Sections[$sectionKey].Add($object)
+    }
+}
+
+function Add-TenantReportStatus {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$Message = 'Not found',
+
+        [Parameter()]
+        [string]$Category
+    )
+
+    Add-TenantReportSection -Name $Name -Category $Category -Data @([pscustomobject]@{ Status = $Message })
+}
+
+function Get-TenantReportSections {
+    [CmdletBinding()]
+    param()
+
+    if (-not $script:TenantReportContext) {
+        return @{}
+    }
+
+    return $script:TenantReportContext.Sections
+}
+
+function Get-TenantReportWorksheetName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [int]$Index
+    )
+
+    if (-not $script:TenantReportContext) {
+        Initialize-TenantReportContext -Title $script:ReportTitle -Version $script:ModuleVersion
+    }
+
+    $cleanName = $Name -replace '[\\\*\?/\[\]:]', ' '
+    $cleanName = ($cleanName -split '\s+') -join ' '
+    $cleanName = $cleanName.Trim()
+
+    if ([string]::IsNullOrEmpty($cleanName)) {
+        $cleanName = "Sheet$Index"
+    }
+
+    if ($cleanName.Length -gt 31) {
+        $cleanName = $cleanName.Substring(0, 31)
+    }
+
+    if (-not $script:TenantReportContext.WorksheetNames) {
+        $script:TenantReportContext.WorksheetNames = @{}
+    }
+
+    $candidate = $cleanName
+    $suffix = 1
+    while ($script:TenantReportContext.WorksheetNames.ContainsKey($candidate)) {
+        $baseName = $cleanName
+        if ($baseName.Length -gt 28) {
+            $baseName = $baseName.Substring(0, 28)
+        }
+        $candidate = "${baseName}_$suffix"
+        if ($candidate.Length -gt 31) {
+            $candidate = $candidate.Substring(0, 31)
+        }
+        $suffix++
+    }
+
+    $script:TenantReportContext.WorksheetNames[$candidate] = $true
+    return $candidate
+}
+
+function Export-TenantReportExcel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $sections = Get-TenantReportSections
+    if (-not $sections.Keys.Count) {
+        Write-Verbose 'No tenant report data available for Excel export.'
+        return
+    }
+
+    try {
+        Import-Module -Name ImportExcel -ErrorAction Stop | Out-Null
+    }
+    catch {
+        Write-Warning "ImportExcel module is not available. Skipping Excel export. $_"
+        return
+    }
+
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Force
+    }
+
+    $index = 1
+    foreach ($entry in $sections.GetEnumerator()) {
+        $rows = $entry.Value
+        if (-not $rows -or $rows.Count -eq 0) {
+            $rows = @([pscustomobject]@{ Status = 'No data available' })
+        }
+
+        $worksheetName = Get-TenantReportWorksheetName -Name $entry.Key -Index $index
+        $tableName = "Tbl$index" + ($worksheetName -replace '[^A-Za-z0-9]', '')
+
+        $params = @{
+            Path          = $Path
+            WorksheetName = $worksheetName
+            TableName     = $tableName
+            InputObject   = $rows
+            AutoSize      = $true
+            AutoFilter    = $true
+            FreezeTopRow  = $true
+            BoldTopRow    = $true
+            TableStyle    = 'Medium2'
+        }
+
+        if ($index -eq 1) {
+            $params['ClearSheet'] = $true
+        }
+
+        Export-Excel @params
+        $index++
+    }
+}

--- a/public/Invoke-AzureAdDeployer.ps1
+++ b/public/Invoke-AzureAdDeployer.ps1
@@ -42,6 +42,8 @@ function Invoke-AzureAdDeployer {
 
     $script:ReportImageUrl = $script:ModuleInfos.PrivateData.PSData.IconUri
 
+    Initialize-TenantReportContext -Title $script:ReportTitle -Version $script:ModuleVersion
+
     $script:InteractiveMode = $false
     $script:MailboxLanguageCode = "de-CH"
     $script:MailboxTimeZone = "W. Europe Standard Time"
@@ -132,6 +134,11 @@ function Invoke-AzureAdDeployer {
     $Report += Get-UserSettingsReport -DisableUserConsent $script:DisableEnterpiseApplicationUserConsent -DisableUsersToCreateAppRegistrations $script:DisableUsersToCreateAppRegistrations -DisableUsersToReadOtherUsers $script:DisableUsersToReadOtherUsers -DisableUsersToCreateSecurityGroups $script:DisableUsersToCreateSecurityGroups -DisableUsersToCreateUnifiedGroups $script:DisableUsersToCreateUnifiedGroups -CreateUnifiedGroupCreationAllowedGroup $script:CreateUnifiedGroupCreationAllowedGroup -EnableBlockMsolPowerShell $script:EnableBlockMsolPowerShell
     $Report += Get-DeviceJoinSettingsReport
     $Report += Get-UsedSKUReport
+    $Report += Get-AllLicenseSKUs -ServiceName 'MGGraph'
+    $Report += Get-AllUserDetails -DetailLevel 'combined' -ServiceName 'MGGraph'
+    $Report += Get-AllOffice365Admins -ServiceName 'MGGraph'
+    $Report += Get-AllDevicesReport -DetailLevel 'combined' -ServiceName 'MGGraph'
+    $Report += Get-EntraIDGroups -DetailLevel 'combined' -ServiceName 'MGGraph' -GraphAuthType 'SDK'
     $Report += Get-AdminRoleReport
     $Report += Get-BreakGlassAccountReport -Create $script:CreateBreakGlassAccount
     $Report += Get-UserMfaStatusReport
@@ -145,12 +152,17 @@ function Invoke-AzureAdDeployer {
         $Report += "<br><hr><h2 id='SPO'>SharePoint Online</h2>"
         Write-Host "SharePoint Online"
         $Report += Get-SPOTenantReport -DisableAddToOneDrive $script:DisableAddToOneDrive
+        $Report += Get-SharePointAndOneDriveSites -DetailLevel 'combined' -ServiceName 'SPO'
     }
     if ($script:AddExchangeOnlineReport -or $script:SetMailboxLanguage -or $script:DisableSharedMailboxLogin -or $script:EnableSharedMailboxCopyToSent -or $script:HideUnifiedMailboxFromOutlookClient) {
         $Report += "<br><hr><h2 id='EXO'>Exchange Online</h2>"
         Write-Host "Exchange Online"
         $Report += Get-MailDomainReport
+        $Report += Get-AllOffice365Domains -ServiceName 'MGGraph'
         $Report += Get-MailConnectorReport
+        $Report += Get-AllRecipientDetails -DetailLevel 'combined'
+        $Report += Get-ExchangeGroupDetails -DetailLevel 'combined'
+        $Report += Get-AllPublicFolderDetails -DetailLevel 'combined' -ExchangeEnvironment 'Office365'
         # $Report += Get-UserMailboxReport -Language $script:SetMailboxLanguage
         $Report += Get-SharedMailboxReport -Language $script:SetMailboxLanguage -DisableLogin $script:DisableSharedMailboxLogin -EnableCopy $script:EnableSharedMailboxCopyToSent
         $Report += Get-UnifiedMailboxReport -HideFromClient $script:HideUnifiedMailboxFromOutlookClient
@@ -183,6 +195,10 @@ function Invoke-AzureAdDeployer {
     $Report = ConvertTo-Html -Body "$ReportTitleHtml $Report" -Title $ReportTitle -Head (Get-Header) -PostContent $PostContentHtml
     $Report | Out-File $Desktop\$ReportName -Force
     Invoke-Item $Desktop\$ReportName
+
+    $ExcelName = ("Microsoft365-Report-$($script:CustomerName)-$(Get-Date -Date $Date -Format 'yyyyMMddHHmm').xlsx").Replace(" ", "")
+    Write-Host "Generating Excel report:" $ExcelName
+    Export-TenantReportExcel -Path (Join-Path $Desktop $ExcelName)
     if ($script:InteractiveMode) { Read-Host "Click [ENTER] to exit $script:ModuleName" }
 }
 Set-Alias aaddepl -Value Invoke-AzureAdDeployer

--- a/public/SharePointOnline/Register-SPOReport.ps1
+++ b/public/SharePointOnline/Register-SPOReport.ps1
@@ -8,7 +8,9 @@ function Get-SPOTenantReport {
         Write-Host "Disable add to OneDrive button"
         Set-PnPTenant -DisableAddToOneDrive $True
     }
-    $Report = Get-PnPTenant | ConvertTo-Html -As List -Property LegacyAuthProtocolsEnabled, DisableAddToOneDrive, ConditionalAccessPolicy, SharingCapability, RequireAcceptingAccountMatchInvitedAccount, PreventExternalUsersFromResharing, DefaultSharingLinkType -Fragment -PreContent "<h3 id='SPO_SETTINGS'>Tenant settings</h3>" -PostContent "<p>ConditionalAccessPolicy: AllowFullAccess, AllowLimitedAccess, BlockAccess</p>
+    $TenantData = Get-PnPTenant | Select-Object LegacyAuthProtocolsEnabled, DisableAddToOneDrive, ConditionalAccessPolicy, SharingCapability, RequireAcceptingAccountMatchInvitedAccount, PreventExternalUsersFromResharing, DefaultSharingLinkType
+    Add-TenantReportSection -Category 'SharePoint Online' -Name 'Tenant settings' -Data $TenantData
+    $Report = $TenantData | ConvertTo-Html -As List -Property LegacyAuthProtocolsEnabled, DisableAddToOneDrive, ConditionalAccessPolicy, SharingCapability, RequireAcceptingAccountMatchInvitedAccount, PreventExternalUsersFromResharing, DefaultSharingLinkType -Fragment -PreContent "<h3 id='SPO_SETTINGS'>Tenant settings</h3>" -PostContent "<p>ConditionalAccessPolicy: AllowFullAccess, AllowLimitedAccess, BlockAccess</p>
 <p>SharingCapability: Disabled, ExternalUserSharingOnly, ExternalUserAndGuestSharing, ExistingExternalUserSharingOnly</p>
 <p>DefaultSharingLinkType: None, Direct, Internal, AnonymousAccess</p>"
     $Report = $Report -Replace "<td>RequireAcceptingAccountMatchInvitedAccount:</td><td>False</td>", "<td>RequireAcceptingAccountMatchInvitedAccount:</td><td class='red'>False</td>"
@@ -20,4 +22,122 @@ function Get-SPOTenantReport {
     $Report = $Report -Replace "<td>PreventExternalUsersFromResharing:</td><td>False</td>", "<td>PreventExternalUsersFromResharing:</td><td class='red'>False</td>"
     $Report = $Report -Replace "<td>DefaultSharingLinkType:</td><td>AnonymousAccess</td>", "<td>DefaultSharingLinkType:</td><td class='red'>AnonymousAccess</td>"
     return $Report
+}
+
+function Get-SharePointAndOneDriveSites {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, HelpMessage = 'Provide the level of detail')]
+        [ValidateSet('minimum', 'combined', 'all', 'geek')]
+        [string]$DetailLevel,
+
+        [Parameter(Mandatory, HelpMessage = 'Provide the service name')]
+        [ValidateSet('MGGraph', 'SPO', 'API')]
+        [string]$ServiceName
+    )
+
+    if ($ServiceName -ne 'SPO') {
+        Write-Warning "Service '$ServiceName' is not currently supported. Falling back to SharePoint Online cmdlets."
+    }
+
+    Write-Host "Checking SharePoint Online and OneDrive sites ($DetailLevel detail)"
+
+    try {
+        switch ($DetailLevel) {
+            'geek' {
+                $sites = Get-SPOSite -IncludePersonalSite $true -Limit All
+            }
+            default {
+                $desiredProperties = @(
+                    'Template', 'IsHubSite', 'Title', 'LastContentModifiedDate', 'Status', 'ArchiveStatus',
+                    'StorageUsageCurrent', 'LockState', 'Url', 'Owner', 'StorageQuota', 'GroupId',
+                    'IsTeamsConnected', 'IsTeamsChannelConnected'
+                )
+
+                $sites = Get-SPOSite -IncludePersonalSite $true -Limit All | Select-Object -Property $desiredProperties
+            }
+        }
+    }
+    catch {
+        Write-Warning "Unable to retrieve SharePoint sites. $_"
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'SharePoint sites' -Message 'Error retrieving site data'
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'OneDrive sites' -Message 'Error retrieving site data'
+        return @(
+            "<br><h3 id='SPO_SITES'>SharePoint sites</h3><p>Error retrieving site data</p>",
+            "<br><h3 id='SPO_ONEDRIVE'>OneDrive sites</h3><p>Error retrieving site data</p>"
+        )
+    }
+
+    if (-not $sites) {
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'SharePoint sites'
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'OneDrive sites'
+        return @(
+            "<br><h3 id='SPO_SITES'>SharePoint sites</h3><p>Not found</p>",
+            "<br><h3 id='SPO_ONEDRIVE'>OneDrive sites</h3><p>Not found</p>"
+        )
+    }
+
+    $siteRows = foreach ($site in $sites) {
+        $isOneDrive = ($site.Url -like '*-my.sharepoint.com*')
+        $storageUsedGb = if ($site.PSObject.Properties.Match('StorageUsageCurrent')) { [math]::Round(($site.StorageUsageCurrent / 1024), 3) } else { $null }
+        $storageQuotaGb = if ($site.PSObject.Properties.Match('StorageQuota') -and $site.StorageQuota) { [math]::Round(($site.StorageQuota / 1024), 3) } else { $null }
+
+        [pscustomobject]@{
+            Title                     = $site.Title
+            Url                       = $site.Url
+            Owner                     = $site.Owner
+            Template                  = $site.Template
+            Status                    = $site.Status
+            ArchiveStatus             = $site.ArchiveStatus
+            IsHubSite                 = $site.IsHubSite
+            LastContentModifiedDate   = $site.LastContentModifiedDate
+            LockState                 = $site.LockState
+            StorageUsageCurrentMB     = $site.StorageUsageCurrent
+            StorageQuotaMB            = $site.StorageQuota
+            StorageUsedGB             = $storageUsedGb
+            StorageQuotaGB            = $storageQuotaGb
+            GroupId                   = $site.GroupId
+            IsTeamsConnected          = $site.IsTeamsConnected
+            IsTeamsChannelConnected   = $site.IsTeamsChannelConnected
+            IsOneDrive                = $isOneDrive
+            DetailLevel               = $DetailLevel
+        }
+    }
+
+    $sharePointSites = $siteRows | Where-Object { -not $_.IsOneDrive }
+    $oneDriveSites = $siteRows | Where-Object { $_.IsOneDrive }
+
+    if ($sharePointSites) {
+        Add-TenantReportSection -Category 'SharePoint Online' -Name 'SharePoint sites' -Data $sharePointSites
+    }
+    else {
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'SharePoint sites'
+    }
+
+    if ($oneDriveSites) {
+        Add-TenantReportSection -Category 'SharePoint Online' -Name 'OneDrive sites' -Data $oneDriveSites
+    }
+    else {
+        Add-TenantReportStatus -Category 'SharePoint Online' -Name 'OneDrive sites'
+    }
+
+    $sharePointHtml = if ($sharePointSites) {
+        $sharePointSites | Select-Object Title, Url, Owner, Template, StorageUsedGB, IsTeamsConnected |
+            ConvertTo-Html -As Table -Property Title, Url, Owner, Template, StorageUsedGB, IsTeamsConnected `
+                -Fragment -PreContent "<br><h3 id='SPO_SITES'>SharePoint sites</h3>"
+    }
+    else {
+        "<br><h3 id='SPO_SITES'>SharePoint sites</h3><p>Not found</p>"
+    }
+
+    $oneDriveHtml = if ($oneDriveSites) {
+        $oneDriveSites | Select-Object Title, Url, Owner, StorageUsedGB, LastContentModifiedDate |
+            ConvertTo-Html -As Table -Property Title, Url, Owner, StorageUsedGB, LastContentModifiedDate `
+                -Fragment -PreContent "<br><h3 id='SPO_ONEDRIVE'>OneDrive sites</h3>"
+    }
+    else {
+        "<br><h3 id='SPO_ONEDRIVE'>OneDrive sites</h3><p>Not found</p>"
+    }
+
+    return @($sharePointHtml, $oneDriveHtml)
 }


### PR DESCRIPTION
## Summary
- add Azure AD inventory collectors for license SKUs, users, directory roles, devices, and Entra ID groups with HTML and Excel output
- extend Exchange Online reporting with tenant domain inventory and remote domain exports
- surface the new sections in the table of contents, orchestrator, and documentation

## Testing
- `pwsh -NoLogo -Command "Test-ModuleManifest -Path ./AzureAdDeployer.psd1"` *(fails: pwsh unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5768070408329915aeffbbc603cbf